### PR TITLE
pify.all() method inclusion/exclusion

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,10 +34,30 @@ var pify = module.exports = function (fn, P, opts) {
 
 pify.all = function (obj, P, opts) {
 	var ret = {};
+	var include = false;
+	var testSet = [];
+
+	if (typeof P !== 'function') {
+		opts = P;
+		P = Promise;
+	}
+
+	opts = opts || {};
+
+	if (opts.include) {
+		include = true;
+		testSet = testSet.concat(opts.include);
+	} else if (opts.exclude) {
+		testSet = testSet.concat(opts.exclude);
+	}
+
+	function filter(key) {
+		return include ^ (testSet.indexOf(key) === -1);
+	}
 
 	Object.keys(obj).forEach(function (key) {
 		var x = obj[key];
-		ret[key] = typeof x === 'function' ? pify(x, P, opts) : x;
+		ret[key] = (typeof x === 'function') && filter(key) ? pify(x, P, opts) : x;
 	});
 
 	return ret;

--- a/index.js
+++ b/index.js
@@ -38,21 +38,21 @@ pify.all = function (obj, P, opts) {
 		P = Promise;
 	}
 
-	var ret = {};
-	var testSet = [];
-
 	opts = opts || {};
 
-	if (opts.include) {
-		testSet = testSet.concat(opts.include);
-	} else if (opts.exclude) {
-		testSet = testSet.concat(opts.exclude);
-	}
+	var filter = function (key) {
+		if (opts.include) {
+			return opts.include.indexOf(key) !== -1;
+		}
 
-	function filter(key) {
-		var found = testSet.indexOf(key) !== -1;
-		return opts.include ? found : !found;
-	}
+		if (opts.exclude) {
+			return opts.exclude.indexOf(key) === -1;
+		}
+
+		return true;
+	};
+
+	var ret = {};
 
 	Object.keys(obj).forEach(function (key) {
 		var x = obj[key];

--- a/index.js
+++ b/index.js
@@ -50,8 +50,8 @@ pify.all = function (obj, P, opts) {
 	}
 
 	function filter(key) {
-		var referred = !(testSet.indexOf(key) === -1);
-		return opts.include ? referred : !referred;
+		var found = !(testSet.indexOf(key) === -1);
+		return opts.include ? found : !found;
 	}
 
 	Object.keys(obj).forEach(function (key) {

--- a/index.js
+++ b/index.js
@@ -33,26 +33,25 @@ var pify = module.exports = function (fn, P, opts) {
 };
 
 pify.all = function (obj, P, opts) {
-	var ret = {};
-	var include = false;
-	var testSet = [];
-
 	if (typeof P !== 'function') {
 		opts = P;
 		P = Promise;
 	}
 
+	var ret = {};
+	var testSet = [];
+
 	opts = opts || {};
 
 	if (opts.include) {
-		include = true;
 		testSet = testSet.concat(opts.include);
 	} else if (opts.exclude) {
 		testSet = testSet.concat(opts.exclude);
 	}
 
 	function filter(key) {
-		return include ^ (testSet.indexOf(key) === -1);
+		var referred = !(testSet.indexOf(key) === -1);
+		return opts.include ? referred : !referred;
 	}
 
 	Object.keys(obj).forEach(function (key) {

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ pify.all = function (obj, P, opts) {
 	}
 
 	function filter(key) {
-		var found = !(testSet.indexOf(key) === -1);
+		var found = testSet.indexOf(key) !== -1;
 		return opts.include ? found : !found;
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,18 @@ pify(request, {multiArgs: true})('http://sindresorhus.com').then(result => {
 });
 ```
 
+##### include
+
+Type: `array`
+
+Works for `pify.all()` **only**. Supply an array of module's methods you want to promisify and only those methods will be transformed. Every other methods will be left untouched.
+
+##### exclude
+
+Type: `array`
+
+Works for `pify.all()` **only**. Supply an array of module's methods you **don't** want to promisify and those methods will be left untouched.
+
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -22,6 +22,10 @@ function fixture3(cb) {
 	});
 }
 
+function fixture4() {
+	return 'unicorn';
+}
+
 test('main', function (t) {
 	t.is(typeof fn(fixture)().then, 'function');
 
@@ -67,4 +71,57 @@ test('module support - preserves non-function members', function (t) {
 	};
 
 	t.same(Object.keys(module), Object.keys(fn.all(module)));
+	t.end();
+});
+
+test('module support - transforms only members in opions.include', function (t) {
+	var module = {
+		method1: fixture,
+		method2: fixture2,
+		method3: fixture4
+	};
+	var pModule = fn.all(module, {
+		include: ['method1', 'method2']
+	});
+
+	t.is(typeof pModule.method1().then, 'function');
+	t.is(typeof pModule.method2('fainbow').then, 'function');
+	t.not(typeof pModule.method3().then, 'function');
+
+	t.end();
+});
+
+test('module support - doesn\'t transform members in opions.exclude', function (t) {
+	var module = {
+		method1: fixture4,
+		method2: fixture4,
+		method3: fixture
+	};
+	var pModule = fn.all(module, {
+		exclude: ['method1', 'method2']
+	});
+
+	t.not(typeof pModule.method1().then, 'function');
+	t.not(typeof pModule.method2().then, 'function');
+	t.is(typeof pModule.method3().then, 'function');
+
+	t.end();
+});
+
+test('module support - options.include over opions.exclude', function (t) {
+	var module = {
+		method1: fixture,
+		method2: fixture2,
+		method3: fixture4
+	};
+	var pModule = fn.all(module, {
+		include: ['method1', 'method2'],
+		exclude: ['method2', 'method3']
+	});
+
+	t.is(typeof pModule.method1().then, 'function');
+	t.is(typeof pModule.method2('rainbow').then, 'function');
+	t.not(typeof pModule.method3().then, 'function');
+
+	t.end();
 });


### PR DESCRIPTION
Added support of include/exclude options for pify.all()

When both include & exclude passed, include is dominating because it is more specific.