### PR TITLE
Method matching

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,21 +35,11 @@ var pify = module.exports = function (obj, P, opts) {
 	opts.exclude = opts.exclude || [/^.+Sync$/];
 
 	var filter = function (key) {
-		var check = function (patterns) {
-			for (var i = 0; i < patterns.length; i++) {
-				if (typeof patterns[i] === 'string') {
-					if (key === patterns[i]) {
-						return true;
-					}
-				} else if ((new RegExp(patterns[i])).test(key)) {
-					return true;
-				}
-			}
-
-			return false;
+		var match = function (pattern) {
+			return typeof pattern === 'string' ? key === pattern : pattern.test(key);
 		};
 
-		return (opts.include) ? check(opts.include) : !check(opts.exclude);
+		return opts.include ? opts.include.some(match) : !opts.exclude.some(match);
 	};
 
 	var ret = (typeof obj === 'function') ? function () {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-var minimatch = require('minimatch');
+var multimatch = require('multimatch');
 
 var process = function (fn, P, opts) {
 	if (typeof fn !== 'function') {
@@ -36,22 +36,14 @@ var pify = module.exports = function (obj, P, opts) {
 	opts.match = opts.match || opts.include;
 
 	if (opts.exclude && !opts.match) {
-		opts.match = opts.exclude.map(function (glob) {
+		opts.match = ['*'].concat(opts.exclude.map(function (glob) {
 			return '!' + glob;
-		});
+		}));
 	}
 
 	var filter = function (key) {
 		if (opts.match) {
-			var include = false;
-			var exclude = false;
-
-			[].concat(opts.match).forEach(function (glob) {
-				exclude = (glob[0] === '!') && minimatch(key, glob, {flipNegate: true}) || exclude;
-				include = minimatch(key, glob) || include;
-			});
-
-			return include && !exclude;
+			return (multimatch(key, opts.match).indexOf(key) !== -1);
 		}
 
 		return true;

--- a/index.js
+++ b/index.js
@@ -2,13 +2,6 @@
 var minimatch = require('minimatch');
 
 var process = function (fn, P, opts) {
-	if (typeof P !== 'function') {
-		opts = P;
-		P = Promise;
-	}
-
-	opts = opts || {};
-
 	if (typeof fn !== 'function') {
 		return P.reject(new TypeError('Expected a function'));
 	}
@@ -40,20 +33,21 @@ var pify = module.exports = function (obj, P, opts) {
 	}
 
 	opts = opts || {};
+	opts.match = opts.match || opts.include;
 
-	if (opts.exclude && !opts.include) {
-		opts.include = opts.exclude.map(function (glob) {
+	if (opts.exclude && !opts.match) {
+		opts.match = opts.exclude.map(function (glob) {
 			return '!' + glob;
 		});
 	}
 
 	var filter = function (key) {
-		if (opts.include) {
+		if (opts.match) {
 			var include = false;
 			var exclude = false;
 
-			[].concat(opts.include).forEach(function (glob) {
-				exclude = ((glob[0] === '!') && minimatch(key, glob.slice(1))) || exclude;
+			[].concat(opts.match).forEach(function (glob) {
+				exclude = (glob[0] === '!') && minimatch(key, glob, {flipNegate: true}) || exclude;
 				include = minimatch(key, glob) || include;
 			});
 

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "ava": "*",
     "pinkie-promise": "^1.0.0",
     "xo": "*"
+  },
+  "dependencies": {
+    "minimatch": "^2.0.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,8 +42,5 @@
     "ava": "*",
     "pinkie-promise": "^1.0.0",
     "xo": "*"
-  },
-  "dependencies": {
-    "multimatch": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "xo": "*"
   },
   "dependencies": {
-    "minimatch": "^2.0.10"
+    "multimatch": "^2.0.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -13,8 +13,8 @@ $ npm install --save pify
 ## Usage
 
 ```js
-import fs from 'fs';
-import pify from 'pify';
+const fs = require('fs');
+const pify = require('pify');
 
 // promisify a single function
 
@@ -95,7 +95,7 @@ Default: `false`
 By default, if given `module` is a function itself, this function will be promisified. Turn this option on if you want to promisify only methods of the module.
 
 ```js
-import pify from 'pify';
+const pify = require('pify');
 
 function fn() {
 	return true;

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ pify(request, {multiArgs: true})('http://sindresorhus.com').then(result => {
 });
 ```
 
-##### include
+##### match
 
 Type: `string` or `array`
 

--- a/readme.md
+++ b/readme.md
@@ -13,18 +13,19 @@ $ npm install --save pify
 ## Usage
 
 ```js
-const fs = require('fs');
-const pify = require('pify');
+import fs from 'fs';
+import pify from 'pify';
+
+// promisify a single function
 
 pify(fs.readFile)('package.json', 'utf8').then(data => {
 	console.log(JSON.parse(data).name);
 	//=> 'pify'
 });
 
-// promisify all methods in a module
-const promiseFs = pify(fs, {include : '!*Sync'});
+// or promisify all methods in a module
 
-promiseFs.readFile('package.json', 'utf8').then(data => {
+pify(fs).readFile('package.json', 'utf8').then(data => {
 	console.log(JSON.parse(data).name);
 	//=> 'pify'
 });
@@ -69,13 +70,22 @@ pify(request, {multiArgs: true})('http://sindresorhus.com').then(result => {
 });
 ```
 
-##### match
+##### include
 
-Type: `string` or `array`
-
-[Glob](https://github.com/isaacs/node-glob#glob-primer) or array of globs.
+Type: `array`
 
 Pick which methods in a module to promisify. Remaining methods will be left untouched.
+
+You can specify either `strings` or `regular expressions` as method names.
+
+##### exclude
+
+Type: `array`  
+Default: `[/^.+Sync$/]`
+
+Pick which methods in a module **not** to promisify. Methods with names ending with `'Sync'` are excluded by default.
+
+You can specify either `strings` or `regular expressions` as method names.
 
 ##### excludeMain
 
@@ -85,7 +95,7 @@ Default: `false`
 By default, if given `module` is a function itself, this function will be promisified. Turn this option on if you want to promisify only methods of the module.
 
 ```js
-const pify = require('pify');
+import pify from 'pify';
 
 function fn() {
 	return true;

--- a/readme.md
+++ b/readme.md
@@ -35,23 +35,13 @@ promiseFs.readFile('package.json', 'utf8').then(data => {
 
 ### pify(input, [promiseModule], [options])
 
-Returns a promise wrapped version of the supplied function.
+Returns a promise wrapped version of the supplied function or module.
 
 #### input
 
-Type: `function`
+Type: `function` or `object`
 
-Callback-style function.
-
-### pify.all(module, [promiseModule], [options])
-
-Returns a version of the module with all its methods promisified.
-
-#### module
-
-Type: `object`
-
-Module whose methods you want to promisify.
+Callback-style function or module whose methods you want to promisify.
 
 #### promiseModule
 
@@ -85,26 +75,12 @@ Type: `string` or `array`
 
 [Glob](https://github.com/isaacs/node-glob#glob-primer) or array of globs.
 
-*Works for `pify.all()` only.*
-
 Pick which methods in a module to promisify. Remaining methods will be left untouched.
-
-##### exclude
-
-Type: `string` or `array`
-
-[Glob](https://github.com/isaacs/node-glob#glob-primer) or array of globs.
-
-*Works for `pify.all()` only.*
-
-Pick which methods in a module **not** to promisify.
 
 ##### excludeMain
 
 Type: `boolean`  
 Default: `false`
-
-*Works for `pify.all()` only.*
 
 By default, if given `module` is a function itself, this function will be promisified. Turn this option on if you want to promisify only methods of the module.
 

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ pify(fs.readFile)('package.json', 'utf8').then(data => {
 });
 
 // promisify all methods in a module
-const promiseFs = pify.all(fs, {include : '!*Sync'});
+const promiseFs = pify(fs, {include : '!*Sync'});
 
 promiseFs.readFile('package.json', 'utf8').then(data => {
 	console.log(JSON.parse(data).name);
@@ -98,7 +98,7 @@ fn.method = (data, callback) => {
 };
 
 // promisify methods but not fn()
-const promiseFn = pify.all(fn, {excludeMain: true});
+const promiseFn = pify(fn, {excludeMain: true});
 
 if (promiseFn()) {
 	promiseFn.method('hi').then(data => {

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ pify(fs.readFile)('package.json', 'utf8').then(data => {
 });
 
 // promisify all methods in a module
-const promiseFs = pify.all(fs);
+const promiseFs = pify.all(fs, {include : '!*Sync'});
 
 promiseFs.readFile('package.json', 'utf8').then(data => {
 	console.log(JSON.parse(data).name);
@@ -81,7 +81,9 @@ pify(request, {multiArgs: true})('http://sindresorhus.com').then(result => {
 
 ##### include
 
-Type: `array`
+Type: `string` or `array`
+
+[Glob](https://github.com/isaacs/node-glob#glob-primer) or array of globs.
 
 *Works for `pify.all()` only.*
 
@@ -89,7 +91,9 @@ Pick which methods in a module to promisify. Remaining methods will be left unto
 
 ##### exclude
 
-Type: `array`
+Type: `string` or `array`
+
+[Glob](https://github.com/isaacs/node-glob#glob-primer) or array of globs.
 
 *Works for `pify.all()` only.*
 

--- a/test.js
+++ b/test.js
@@ -95,7 +95,7 @@ test('module support - transforms only members in opions.include', function (t) 
 	};
 
 	var pModule = fn.all(module, {
-		include: ['method1', 'method2']
+		include: ['method*', '!method3']
 	});
 
 	t.is(typeof pModule.method1().then, 'function');
@@ -154,5 +154,10 @@ test('module support — function modules exclusion', function (t) {
 
 	t.is(typeof pModule.meow().then, 'function');
 	t.not(typeof pModule(function () {}).then, 'function');
+	t.end();
+});
+
+test('module support – glob exclusion', function (t) {
+	t.is(typeof fn.all(fs, {include: '!*Sync'}).readFileSync('package.json', 'utf8'), 'string');
 	t.end();
 });

--- a/test.js
+++ b/test.js
@@ -22,21 +22,27 @@ function fixture3(cb) {
 	});
 }
 
-function fixture4() {
-	return 'unicorn';
-}
-
-function fixture5(cb) {
+function fixture4(cb) {
 	setImmediate(function () {
 		cb(null, 'unicorn');
 	});
-	return true;
+	return 'rainbow';
 }
 
-fixture5.meow = function (cb) {
+fixture4.meow = function (cb) {
 	setImmediate(function () {
 		cb(null, 'unicorn');
 	});
+};
+
+function fixture5() {
+	return 'rainbow';
+}
+
+var fixtureModule = {
+	method1: fixture,
+	method2: fixture,
+	method3: fixture5
 };
 
 test('main', function (t) {
@@ -72,9 +78,15 @@ test('wrap core method', function (t) {
 });
 
 test('module support', function (t) {
-	return fn.all(fs).readFile('package.json').then(function (data) {
+	return fn(fs).readFile('package.json').then(function (data) {
 		t.is(JSON.parse(data).name, 'pify');
 	});
+});
+
+test('module support - doesn\'t transform *Sync methods by default', function (t) {
+	var data = fn(fs).readFileSync('package.json');
+	t.is(JSON.parse(data).name, 'pify');
+	t.end();
 });
 
 test('module support - preserves non-function members', function (t) {
@@ -83,64 +95,46 @@ test('module support - preserves non-function members', function (t) {
 		nonMethod: 3
 	};
 
-	t.same(Object.keys(module), Object.keys(fn.all(module)));
+	t.same(Object.keys(module), Object.keys(fn(module)));
 	t.end();
 });
 
 test('module support - transforms only members in opions.include', function (t) {
-	var module = {
-		method1: fixture,
-		method2: fixture2,
-		method3: fixture4
-	};
-
-	var pModule = fn.all(module, {
-		include: ['method*', '!method3']
+	var pModule = fn(fixtureModule, {
+		include: ['method1', 'method2']
 	});
 
 	t.is(typeof pModule.method1().then, 'function');
-	t.is(typeof pModule.method2('fainbow').then, 'function');
+	t.is(typeof pModule.method2().then, 'function');
 	t.not(typeof pModule.method3().then, 'function');
 	t.end();
 });
 
 test('module support - doesn\'t transform members in opions.exclude', function (t) {
-	var module = {
-		method1: fixture4,
-		method2: fixture4,
-		method3: fixture
-	};
-
-	var pModule = fn.all(module, {
-		exclude: ['method1', 'method2']
+	var pModule = fn(fixtureModule, {
+		exclude: ['method3']
 	});
 
-	t.not(typeof pModule.method1().then, 'function');
-	t.not(typeof pModule.method2().then, 'function');
-	t.is(typeof pModule.method3().then, 'function');
+	t.is(typeof pModule.method1().then, 'function');
+	t.is(typeof pModule.method2().then, 'function');
+	t.not(typeof pModule.method3().then, 'function');
 	t.end();
 });
 
 test('module support - options.include over opions.exclude', function (t) {
-	var module = {
-		method1: fixture,
-		method2: fixture2,
-		method3: fixture4
-	};
-
-	var pModule = fn.all(module, {
+	var pModule = fn(fixtureModule, {
 		include: ['method1', 'method2'],
 		exclude: ['method2', 'method3']
 	});
 
 	t.is(typeof pModule.method1().then, 'function');
-	t.is(typeof pModule.method2('rainbow').then, 'function');
+	t.is(typeof pModule.method2().then, 'function');
 	t.not(typeof pModule.method3().then, 'function');
 	t.end();
 });
 
 test('module support — function modules', function (t) {
-	var pModule = fn.all(fixture5);
+	var pModule = fn(fixture4);
 
 	t.is(typeof pModule().then, 'function');
 	t.is(typeof pModule.meow().then, 'function');
@@ -148,16 +142,11 @@ test('module support — function modules', function (t) {
 });
 
 test('module support — function modules exclusion', function (t) {
-	var pModule = fn.all(fixture5, {
+	var pModule = fn(fixture4, {
 		excludeMain: true
 	});
 
 	t.is(typeof pModule.meow().then, 'function');
 	t.not(typeof pModule(function () {}).then, 'function');
-	t.end();
-});
-
-test('module support – glob exclusion', function (t) {
-	t.is(typeof fn.all(fs, {include: '!*Sync'}).readFileSync('package.json', 'utf8'), 'string');
 	t.end();
 });


### PR DESCRIPTION
I thought it would be handy if we could pick methods to promisify using **globs**. This way we can drop `opts.exclude` while being able to do this:

```js
const fs = require('fs');
const pify = require('pify');

const pfs = pify(fs, {include: ['write*', '!*Sync']});
```

It adds one dependency to pify – [multimatch](https://github.com/sindresorhus/multimatch) – which is quite small.

I also realized today that `pify.all()` can do the same thing as `pify()` so we are able to simplify the API back to one single function! I did that and tested with existing test and it all worked.

---

For compatibility I left `pify.all` as an alias for `pify` and added this code:

```js
if (opts.exclude && !opts.include) {
	opts.include = opts.exclude.map(function (glob) {
		return '!' + glob;
	});
}
```

... to keep `opts.exclude` working.

---

**For the record**: @sindresorhus [suggested](https://github.com/sindresorhus/pify/pull/10#issuecomment-149489339) to use RegExp instead of globbing, so this is what this PR is about now.