### PR TITLE
do not prevent v8 optimizing of promisified functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,14 +14,23 @@ var pify = module.exports = function (fn, P, opts) {
 
 	return function () {
 		var that = this;
-		var args = [].slice.call(arguments);
+		var args = new Array(arguments.length);
+
+		for (var i = 0; i < arguments.length; i++) {
+			args[i] = arguments[i];
+		}
 
 		return new P(function (resolve, reject) {
 			args.push(function (err, result) {
 				if (err) {
 					reject(err);
 				} else if (opts.multiArgs) {
-					resolve([].slice.call(arguments, 1));
+					var results = new Array(arguments.length - 1);
+
+					for (var i = 1; i < arguments.length; i++) {
+						results[i - 1] = arguments[i];
+					}
+					resolve(results);
 				} else {
 					resolve(result);
 				}

--- a/optimization-test.js
+++ b/optimization-test.js
@@ -1,0 +1,43 @@
+/* eslint no-inline-comments:0, lines-around-comment:0, no-fallthrough:0 */
+'use strict';
+var assert = require('assert');
+var Promise = require('pinkie-promise');
+var v8 = require('v8-natives');
+var fn = require('./');
+
+function assertOptimized(fn, name) {
+	var status = v8.getOptimizationStatus(fn);
+
+	switch (status) {
+		case 1:
+			// fn is optimized
+			return;
+		case 2:
+			assert(false, name + ' is not optimized (' + status + ')');
+		case 3:
+			// fn is always optimized
+			return;
+		case 4:
+			assert(false, name + ' is never optimized (' + status + ')');
+		case 6:
+			assert(false, name + ' is maybe deoptimized (' + status + ')');
+		default:
+			assert(false, 'unknown OptimizationStatus: ' + status + ' (' + name + ')');
+	}
+}
+
+var sut = fn.all({
+	unicorn: function (cb) {
+		cb(null, 'unicorn');
+	}
+}, Promise);
+
+sut.unicorn().then(function () {
+	v8.optimizeFunctionOnNextCall(sut.unicorn);
+	return sut.unicorn().then(function () {
+		assertOptimized(sut.unicorn, 'unicorn');
+	});
+}).catch(function (err) {
+	console.log(err.stack);
+	process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "xo && ava"
+    "test": "xo && ava && npm run optimization-test",
+    "optimization-test": "node --allow-natives-syntax optimization-test.js"
   },
   "files": [
     "index.js"
@@ -41,6 +42,7 @@
   "devDependencies": {
     "ava": "*",
     "pinkie-promise": "^1.0.0",
+    "v8-natives": "0.0.2",
     "xo": "*"
   }
 }


### PR DESCRIPTION
`[].slice.call(arguments)` is known as an [_Optimization Killer_](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#32-leaking-arguments), at least in V8:

```js
var unicornP = pify(function unicorn(cb) {…});
// => unicornP can not be optimized
```

This PR uses the workaround, mentioned in the Wiki article above:
```js
var args = new Array(arguments.length);

for (var i = 0; i < arguments.length; i++) {
	args[i] = arguments[i];
}
```