### PR TITLE
Support transforming inherited methods

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import util from 'util';
 import test from 'ava';
 import pinkiePromise from 'pinkie-promise';
 import fn from './';
@@ -24,6 +25,23 @@ const fixtureModule = {
 	method2: fixture,
 	method3: fixture5
 };
+
+function FixtureGrandparent() {}
+FixtureGrandparent.prototype.grandparentMethod1 = fixture;
+FixtureGrandparent.prototype.overriddenMethod1 = fixture;
+function FixtureParent() {}
+util.inherits(FixtureParent, FixtureGrandparent);
+FixtureParent.prototype.parentMethod1 = fixture;
+FixtureParent.prototype.overriddenMethod1 = fixture2;
+FixtureParent.prototype.overriddenValue1 = 2;
+function FixtureClass() {
+	this.instanceMethod1 = fixture;
+	this.instanceValue1 = 72;
+}
+util.inherits(FixtureClass, FixtureParent);
+FixtureClass.prototype.method1 = fixture;
+FixtureParent.prototype.overriddenValue1 = 4;
+FixtureClass.prototype.value1 = 'neo';
 
 test('main', async t => {
 	t.is(typeof fn(fixture)().then, 'function');
@@ -108,4 +126,102 @@ test('module support — function modules exclusion', t => {
 
 	t.is(typeof pModule.meow().then, 'function');
 	t.not(typeof pModule(() => {}).then, 'function');
+});
+
+test('class support — works for class instances', t => {
+	const instance = new FixtureClass();
+	const pInstance = fn(instance);
+
+	t.deepEqual(Object.keys(instance), Object.keys(pInstance));
+	t.is(typeof pInstance.instanceMethod1().then, 'function');
+});
+
+test('class support — options.inherited transforms inherited methods', t => {
+	const instance = new FixtureClass();
+	const pInstance = fn(instance, {
+		inherited: true
+	});
+
+	const flattened = {};
+	for (let prot = instance; prot; prot = Object.getPrototypeOf(prot)) {
+		Object.assign(flattened, prot);
+	}
+
+	const keys = Object.keys(flattened);
+	keys.sort();
+	const pKeys = Object.keys(pInstance);
+	pKeys.sort();
+	t.deepEqual(keys, pKeys);
+
+	t.is(instance.value1, pInstance.value1);
+	t.is(typeof pInstance.instanceMethod1().then, 'function');
+	t.is(typeof pInstance.method1().then, 'function');
+	t.is(typeof pInstance.parentMethod1().then, 'function');
+	t.is(typeof pInstance.grandparentMethod1().then, 'function');
+});
+
+test('class support — preserves prototype', t => {
+	const instance = new FixtureClass();
+	const pInstance = fn(instance, {
+		inherited: true
+	});
+
+	t.true(pInstance instanceof FixtureClass);
+});
+
+test('class support — respects inheritance order', async t => {
+	const instance = new FixtureClass();
+	const pInstance = fn(instance, {
+		inherited: true
+	});
+
+	t.is(instance.overriddenValue1, pInstance.overriddenValue1);
+	t.is(await pInstance.overriddenMethod1('rainbow'), 'rainbow');
+});
+
+test('class support - transforms only members in options.include, copies all', t => {
+	const instance = new FixtureClass();
+	const pInstance = fn(instance, {
+		include: ['parentMethod1'],
+		inherited: true
+	});
+
+	const flattened = {};
+	for (let prot = instance; prot; prot = Object.getPrototypeOf(prot)) {
+		Object.assign(flattened, prot);
+	}
+
+	const keys = Object.keys(flattened);
+	keys.sort();
+	const pKeys = Object.keys(pInstance);
+	pKeys.sort();
+	t.deepEqual(keys, pKeys);
+
+	t.is(typeof pInstance.parentMethod1().then, 'function');
+	t.not(typeof pInstance.method1(() => {}).then, 'function');
+	t.not(typeof pInstance.grandparentMethod1(() => {}).then, 'function');
+});
+
+test('class support - doesn\'t transform members in options.exclude', t => {
+	const instance = new FixtureClass();
+	const pInstance = fn(instance, {
+		exclude: ['grandparentMethod1'],
+		inherited: true
+	});
+
+	t.not(typeof pInstance.grandparentMethod1(() => {}).then, 'function');
+	t.is(typeof pInstance.parentMethod1().then, 'function');
+});
+
+test('class support - options.include over options.exclude', t => {
+	const instance = new FixtureClass();
+	const pInstance = fn(instance, {
+		include: ['method1', 'parentMethod1'],
+		exclude: ['parentMethod1', 'grandparentMethod1'],
+		inherited: true
+	});
+
+	t.is(typeof pInstance.method1().then, 'function');
+	t.is(typeof pInstance.parentMethod1().then, 'function');
+	t.not(typeof pInstance.grandparentMethod1(() => {}).then, 'function');
 });


### PR DESCRIPTION
This makes it possible to transform objects which are instances of a class without knowing which methods are present on the instance object and which are inherited through the prototype chain, as discussed in #14.  Include/Exclude is handled the same as for non-inherited methods.

In addition to transforming inherited methods, when the `inherited` option is enabled the result object is created with the prototype of the original object so that it behaves the same as the original object for `instanceof` checks.  I think this fits with the intended use of `inherited`, but if you would prefer a separate option or a separate PR, let me know and I'll split it out.

This PR also copies all properties from the original object to the target, even if excluded, to match the current behavior.  It may make more sense to avoid copying values and/or excluded methods which would be inherited, both to avoid unnecessary copies and so any updates to the prototype are shared.  But I left that behavior out of this PR for simplicity.  Let me know if you would prefer that behavior.

Thanks for considering,
Kevin

Fixes #14
