### PR TITLE
add allArgs option

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,13 +11,14 @@ var processFn = function (fn, P, opts) {
 
 		return new P(function (resolve, reject) {
 			args.push(function (err, result) {
-				if (err) {
+				if (err && !opts.allArgs) {
 					reject(err);
-				} else if (opts.multiArgs) {
-					var results = new Array(arguments.length - 1);
+				} else if (opts.multiArgs || opts.allArgs) {
+					var offset = opts.allArgs ? 0 : 1;
+					var results = new Array(arguments.length - offset);
 
-					for (var i = 1; i < arguments.length; i++) {
-						results[i - 1] = arguments[i];
+					for (var i = offset; i < arguments.length; i++) {
+						results[i - offset] = arguments[i];
 					}
 
 					resolve(results);

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,25 @@ pify(request, {multiArgs: true})('https://sindresorhus.com').then(result => {
 });
 ```
 
+##### allArgs
+
+Type: `boolean`
+Default: `false`
+
+By default, the promisified function will only return the second argument from the callback. Turning this on will make it return an array of all arguments from the callback, *including* the error argument.
+
+```js
+const request = require('request');
+const pify = require('pify');
+
+const fn = async () => {
+	const [error, httpResponse, body] = await pify(request, {allArgs: true})('https://sindresorhus.com');
+	if (error || httpResponse.status !== 200) {
+		console.log('Error!');
+	}
+}
+```
+
 ##### include
 
 Type: `array` of (`string`|`regex`)

--- a/test.js
+++ b/test.js
@@ -64,6 +64,10 @@ test('multiArgs option', async t => {
 	t.same(await fn(fixture3, {multiArgs: true})(), ['unicorn', 'rainbow']);
 });
 
+test('allArgs option', async t => {
+	t.same(await fn(fixture3, {allArgs: true})(), [null, 'unicorn', 'rainbow']);
+});
+
 test('wrap core method', async t => {
 	t.is(JSON.parse(await fn(fs.readFile)('package.json')).name, 'pify');
 });


### PR DESCRIPTION
which allows returning all arguments (including error).

My specific use-case is more about a series of `await`s and how it looks when you have to have to wrap them in a nested try-catch -without this option- to handle a specific error. See example below.

with `allArgs` (less nesting):
```js
try {
  await pify(step1)();
  const [err] = await pify(step2, {allArgs: true})();
  if(err) { 
     // handle specific recoverable error and re-throw others I don't care about
  }
  await pify(step3)();
} catch (e) {
  //handle other errors
}
```

without `allArgs`:
```js
try {
  await pify(step1)();
  try {
    await pify(step2)();
  } catch (e) {
     // handle specific recoverable error and re-throw others I don't care about
  }
  await pify(step3)();
} catch (e) {
  //handle other errors
}
```

I know that always just resolving is not naturally 'promisy' but personally this just feels better in some cases (see above).

A nice side-effect is that non-error first APIs (yeah, I know, they're really rare if there are any :D) can also be supported this way and it's just a small flag and minimal logic.