### PR TITLE
tweaks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,3 @@ insert_final_newline = true
 [{package.json,*.yml}]
 indent_style = space
 indent_size = 2
-
-[*.md]
-trim_trailing_whitespace = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-  - 'stable'
+  - '5'
+  - '4'
   - '0.12'
   - '0.10'

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ Check out [`pinkie-promise`](https://github.com/floatdrop/pinkie-promise) if you
 
 ##### multiArgs
 
-Type: `boolean`  
+Type: `boolean`<br>
 Default: `false`
 
 By default, the promisified function will only return the second argument from the callback, which works fine for most APIs. This option can be useful for modules like `request` that return multiple arguments. Turning this on will make it return an array of all arguments from the callback, excluding the error argument, instead of just the second argument.
@@ -78,14 +78,14 @@ Methods in a module to promisify. Remaining methods will be left untouched.
 
 ##### exclude
 
-Type: `array` of (`string`|`regex`)  
+Type: `array` of (`string`|`regex`)<br>
 Default: `[/.+Sync$/]`
 
 Methods in a module **not** to promisify. Methods with names ending with `'Sync'` are excluded by default.
 
 ##### excludeMain
 
-Type: `boolean`  
+Type: `boolean`<br>
 Default: `false`
 
 By default, if given module is a function itself, this function will be promisified. Turn this option on if you want to promisify only methods of the module.

--- a/test.js
+++ b/test.js
@@ -5,31 +5,13 @@ import fn from './';
 
 global.Promise = pinkiePromise;
 
-function fixture(cb) {
-	setImmediate(() => {
-		cb(null, 'unicorn');
-	});
-}
-
-function fixture2(x, cb) {
-	setImmediate(() => {
-		cb(null, x);
-	});
-}
-
-function fixture3(cb) {
-	setImmediate(() => {
-		cb(null, 'unicorn', 'rainbow');
-	});
-}
-
-function fixture4(cb) {
-	setImmediate(() => {
-		cb(null, 'unicorn');
-	});
-
+const fixture = cb => setImmediate(() => cb(null, 'unicorn'));
+const fixture2 = (x, cb) => setImmediate(() => cb(null, x));
+const fixture3 = cb => setImmediate(() => cb(null, 'unicorn', 'rainbow'));
+const fixture4 = cb => setImmediate(() => {
+	cb(null, 'unicorn');
 	return 'rainbow';
-}
+});
 
 fixture4.meow = cb => {
 	setImmediate(() => {
@@ -37,9 +19,7 @@ fixture4.meow = cb => {
 	});
 };
 
-function fixture5() {
-	return 'rainbow';
-}
+const fixture5 = () => 'rainbow';
 
 const fixtureModule = {
 	method1: fixture,
@@ -85,7 +65,7 @@ test('module support - preserves non-function members', t => {
 	t.deepEqual(Object.keys(module), Object.keys(fn(module)));
 });
 
-test('module support - transforms only members in opions.include', t => {
+test('module support - transforms only members in options.include', t => {
 	const pModule = fn(fixtureModule, {
 		include: ['method1', 'method2']
 	});
@@ -95,7 +75,7 @@ test('module support - transforms only members in opions.include', t => {
 	t.not(typeof pModule.method3().then, 'function');
 });
 
-test('module support - doesn\'t transform members in opions.exclude', t => {
+test('module support - doesn\'t transform members in options.exclude', t => {
 	const pModule = fn(fixtureModule, {
 		exclude: ['method3']
 	});
@@ -105,7 +85,7 @@ test('module support - doesn\'t transform members in opions.exclude', t => {
 	t.not(typeof pModule.method3().then, 'function');
 });
 
-test('module support - options.include over opions.exclude', t => {
+test('module support - options.include over options.exclude', t => {
 	const pModule = fn(fixtureModule, {
 		include: ['method1', 'method2'],
 		exclude: ['method2', 'method3']


### PR DESCRIPTION
The [fixtures](https://github.com/sindresorhus/pify/blob/master/test.js#L8-L24) can be written a little bit shorter as well. Let me know if you want that.

```js
const fixture = cb => setImmediate(() => cb(null, 'unicorn'));
const fixture2 = (x, cb) => setImmediate(() => cb(null, x));
```