### PR TITLE
Allow promisification of a single object method:

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,10 @@ var pify = module.exports = function (obj, P, opts) {
 		P = Promise;
 	}
 
+	if (typeof opts === 'string') {
+		return processFn(obj[opts], P, {}).bind(obj);
+	}
+
 	opts = opts || {};
 	var exclude = opts.exclude || [/.+Sync$/];
 

--- a/optimization-test.js
+++ b/optimization-test.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-fallthrough */
+/* eslint-disable no-fallthrough, xo/no-process-exit*/
 'use strict';
 var assert = require('assert');
 var Promise = require('pinkie-promise');

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ pify(fs).readFile('package.json', 'utf8').then(data => {
 
 ## API
 
-### pify(input, [promiseModule], [options])
+### pify(input, [promiseModule], [methodName | options])
 
 Returns a promise wrapped version of the supplied function or module.
 
@@ -51,6 +51,24 @@ Type: `function`
 Custom promise module to use instead of the native one.
 
 Check out [`pinkie-promise`](https://github.com/floatdrop/pinkie-promise) if you need a tiny promise polyfill.
+
+#### methodName
+
+Type: `string`
+
+Specify a specific member function of `input` to promisify:
+
+```js
+var x = {
+  a: 'foo',
+  b: function (b, cb) {
+    cb(null, this.a + b);
+  }
+};
+
+pify(x, 'b')('bar')
+//=> Promise for "foobar"
+```
 
 #### options
 

--- a/test.js
+++ b/test.js
@@ -27,6 +27,16 @@ const fixtureModule = {
 	method3: fixture5
 };
 
+class Concat {
+	constructor(a) {
+		this.a = a;
+	}
+
+	b(b, cb) {
+		setImmediate(() => cb(null, this.a + b));
+	}
+}
+
 test('main', async t => {
 	t.is(typeof fn(fixture)().then, 'function');
 	t.is(await fn(fixture)(), 'unicorn');
@@ -42,6 +52,12 @@ test('custom Promise module', async t => {
 
 test('multiArgs option', async t => {
 	t.deepEqual(await fn(fixture3, {multiArgs: true})(), ['unicorn', 'rainbow']);
+});
+
+test('string option returns promisified thunk for member function', async t => {
+	const concat = new Concat('foo');
+
+	t.is(await fn(concat, 'b')('bar'), 'foobar');
 });
 
 test('wrap core method', async t => {


### PR DESCRIPTION
This allows `opts` to be a `string`. If so, it will promisify the named function of `input` and return a thunk with `this` bound to `input`.

This is really handy for chainable structures, where binding `this` can get a little verbose:

```js
var bundler = browserify()
  .require(file)
  .transform(brfs)
  .exclued(excluded);

return pify(bundler.bundle.bind(bundler))();
```

becomes

```js 
return pify(
  browserify()
    .require(file)
    .transform(brfs)
    .exclued(excluded),
  'bundle'
)();
```