### PR TITLE
add bind option

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,11 +39,7 @@ var pify = module.exports = function (obj, P, opts) {
 
 	opts = opts || {};
 	var exclude = opts.exclude || [/.+Sync$/];
-	var bind = opts.bind === false ? false : (opts.bind || obj);
-
-	if (bind === true) {
-		bind = obj;
-	}
+	var bind = opts.bind === false ? false : obj;
 
 	var filter = function (key) {
 		var match = function (pattern) {
@@ -70,18 +66,7 @@ var pify = module.exports = function (obj, P, opts) {
 			}
 
 			ret[key] = x;
-		} else if (bind) {
-			Object.defineProperty(ret, key, {
-				enumerable: true,
-				configurable: true,
-				get: function () {
-					return bind[key];
-				},
-				set: function (val) {
-					bind[key] = val;
-				}
-			});
-		} else {
+		} else if (!bind) {
 			ret[key] = x;
 		}
 

--- a/index.js
+++ b/index.js
@@ -39,7 +39,11 @@ var pify = module.exports = function (obj, P, opts) {
 
 	opts = opts || {};
 	var exclude = opts.exclude || [/.+Sync$/];
-	var bind = opts.bind === false ? false : obj;
+	var bind = opts.bind === false ? false : (opts.bind || obj);
+
+	if (bind === true) {
+		bind = obj;
+	}
 
 	var filter = function (key) {
 		var match = function (pattern) {
@@ -66,7 +70,18 @@ var pify = module.exports = function (obj, P, opts) {
 			}
 
 			ret[key] = x;
-		} else if (!bind) {
+		} else if (bind) {
+			Object.defineProperty(ret, key, {
+				enumerable: true,
+				configurable: true,
+				get: function () {
+					return bind[key];
+				},
+				set: function (val) {
+					bind[key] = val;
+				}
+			});
+		} else {
 			ret[key] = x;
 		}
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var processFn = function (fn, P, opts) {
+var processFn = function (fn, P, opts, bind) {
 	return function () {
-		var that = this;
+		var that = bind || this;
 		var args = new Array(arguments.length);
 
 		for (var i = 0; i < arguments.length; i++) {
@@ -39,6 +39,11 @@ var pify = module.exports = function (obj, P, opts) {
 
 	opts = opts || {};
 	var exclude = opts.exclude || [/.+Sync$/];
+	var bind = opts.bind === false ? false : (opts.bind || obj);
+
+	if (bind === true) {
+		bind = obj;
+	}
 
 	var filter = function (key) {
 		var match = function (pattern) {
@@ -59,7 +64,26 @@ var pify = module.exports = function (obj, P, opts) {
 	return Object.keys(obj).reduce(function (ret, key) {
 		var x = obj[key];
 
-		ret[key] = typeof x === 'function' && filter(key) ? processFn(x, P, opts) : x;
+		if (typeof x === 'function') {
+			if (filter(key)) {
+				x = processFn(x, P, opts, bind);
+			}
+
+			ret[key] = x;
+		} else if (bind) {
+			Object.defineProperty(ret, key, {
+				enumerable: true,
+				configurable: true,
+				get: function () {
+					return bind[key];
+				},
+				set: function (val) {
+					bind[key] = val;
+				}
+			});
+		} else {
+			ret[key] = x;
+		}
 
 		return ret;
 	}, ret);

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ var pify = module.exports = function (obj, P, opts) {
 		return processFn(obj, P, opts).apply(this, arguments);
 	} : {};
 
-	return Object.keys(obj).reduce(function (ret, key) {
+	function bindProperty(key) {
 		var x = obj[key];
 
 		if (typeof x === 'function') {
@@ -84,9 +84,13 @@ var pify = module.exports = function (obj, P, opts) {
 		} else {
 			ret[key] = x;
 		}
+	}
 
-		return ret;
-	}, ret);
+	for (var key in obj) { // eslint-disable-line guard-for-in
+		bindProperty(key);
+	}
+
+	return ret;
 };
 
 pify.all = pify;

--- a/optimization-test.js
+++ b/optimization-test.js
@@ -40,5 +40,5 @@ sut.unicorn().then(function () {
 	});
 }).catch(function (err) {
 	console.log(err.stack);
-	process.exit(1);
+	process.exit(1); // eslint-disable-line xo/no-process-exit
 });

--- a/test.js
+++ b/test.js
@@ -60,6 +60,7 @@ test('binds to the original object by default', async t => {
 	obj.x = 'bar';
 
 	t.is(await pified.y(), 'bar');
+	t.is(pified.x, 'bar');
 });
 
 test('bind:true will bind to the original object', async t => {
@@ -74,6 +75,24 @@ test('bind:true will bind to the original object', async t => {
 	obj.x = 'bar';
 
 	t.is(await pified.y(), 'bar');
+	t.is(pified.x, 'bar');
+});
+
+test('bind:otherObj will bind to otherObj', async t => {
+	const obj = {
+		x: 'foo',
+		y: function (cb) {
+			setImmediate(() => cb(null, this.x));
+		}
+	};
+
+	const otherObj = {
+		x: 'baz'
+	};
+
+	const pified = fn(obj, {bind: otherObj});
+
+	t.is(await pified.y(), 'baz');
 });
 
 test('bind:false creates a copy', async t => {
@@ -100,13 +119,13 @@ test('module support - doesn\'t transform *Sync methods by default', t => {
 	t.is(JSON.parse(fn(fs).readFileSync('package.json')).name, 'pify');
 });
 
-test('module support - preserves non-function members when not binding', t => {
+test('module support - preserves non-function members', t => {
 	const module = {
 		method: function () {},
 		nonMethod: 3
 	};
 
-	t.deepEqual(Object.keys(module), Object.keys(fn(module, {bind: false})));
+	t.deepEqual(Object.keys(module), Object.keys(fn(module)));
 });
 
 test('module support - transforms only members in options.include', t => {

--- a/test.js
+++ b/test.js
@@ -48,6 +48,69 @@ test('wrap core method', async t => {
 	t.is(JSON.parse(await fn(fs.readFile)('package.json')).name, 'pify');
 });
 
+test('binds to the original object by default', async t => {
+	const obj = {
+		x: 'foo',
+		y: function (cb) {
+			setImmediate(() => cb(null, this.x));
+		}
+	};
+
+	const pified = fn(obj);
+	obj.x = 'bar';
+
+	t.is(await pified.y(), 'bar');
+	t.is(pified.x, 'bar');
+});
+
+test('bind:true will bind to the original object', async t => {
+	const obj = {
+		x: 'foo',
+		y: function (cb) {
+			setImmediate(() => cb(null, this.x));
+		}
+	};
+
+	const pified = fn(obj, {bind: true});
+	obj.x = 'bar';
+
+	t.is(await pified.y(), 'bar');
+	t.is(pified.x, 'bar');
+});
+
+test('bind:otherObj will bind to otherObj', async t => {
+	const obj = {
+		x: 'foo',
+		y: function (cb) {
+			setImmediate(() => cb(null, this.x));
+		}
+	};
+
+	const otherObj = {
+		x: 'baz'
+	};
+
+	const pified = fn(obj, {bind: otherObj});
+
+	t.is(await pified.y(), 'baz');
+});
+
+test('bind:false creates a copy', async t => {
+	const obj = {
+		x: 'foo',
+		y: function (cb) {
+			setImmediate(() => cb(null, this.x));
+		}
+	};
+
+	const pified = fn(obj, {bind: false});
+
+	obj.x = 'bar';
+
+	t.is(await pified.y(), 'foo');
+	t.is(pified.x, 'foo');
+});
+
 test('module support', async t => {
 	t.is(JSON.parse(await fn(fs).readFile('package.json')).name, 'pify');
 });

--- a/test.js
+++ b/test.js
@@ -111,6 +111,26 @@ test('bind:false creates a copy', async t => {
 	t.is(pified.x, 'foo');
 });
 
+test('bind:true will include prototype methods', async t => {
+	function Foo() {}
+
+	Foo.prototype.y = function (arg, cb) {
+		setImmediate(() => cb(null, this.x + arg));
+	};
+
+	Foo.prototype.x = 'foo';
+
+	const foo = new Foo();
+	const pified = fn(foo);
+
+	t.is(await pified.y('BAR'), 'fooBAR');
+
+	pified.x = 'FOO';
+
+	t.is(await pified.y('bar'), 'FOObar');
+	t.is(foo.x, 'FOO');
+});
+
 test('module support', async t => {
 	t.is(JSON.parse(await fn(fs).readFile('package.json')).name, 'pify');
 });

--- a/test.js
+++ b/test.js
@@ -60,7 +60,6 @@ test('binds to the original object by default', async t => {
 	obj.x = 'bar';
 
 	t.is(await pified.y(), 'bar');
-	t.is(pified.x, 'bar');
 });
 
 test('bind:true will bind to the original object', async t => {
@@ -75,24 +74,6 @@ test('bind:true will bind to the original object', async t => {
 	obj.x = 'bar';
 
 	t.is(await pified.y(), 'bar');
-	t.is(pified.x, 'bar');
-});
-
-test('bind:otherObj will bind to otherObj', async t => {
-	const obj = {
-		x: 'foo',
-		y: function (cb) {
-			setImmediate(() => cb(null, this.x));
-		}
-	};
-
-	const otherObj = {
-		x: 'baz'
-	};
-
-	const pified = fn(obj, {bind: otherObj});
-
-	t.is(await pified.y(), 'baz');
 });
 
 test('bind:false creates a copy', async t => {
@@ -119,13 +100,13 @@ test('module support - doesn\'t transform *Sync methods by default', t => {
 	t.is(JSON.parse(fn(fs).readFileSync('package.json')).name, 'pify');
 });
 
-test('module support - preserves non-function members', t => {
+test('module support - preserves non-function members when not binding', t => {
 	const module = {
 		method: function () {},
 		nonMethod: 3
 	};
 
-	t.deepEqual(Object.keys(module), Object.keys(fn(module)));
+	t.deepEqual(Object.keys(module), Object.keys(fn(module, {bind: false})));
 });
 
 test('module support - transforms only members in options.include', t => {


### PR DESCRIPTION
By default, it binds functions to the original object.

If `opts.bind` is `false`. It does not bind to the original object, and copies over all non-function properties.
## 

Closes #26.
