### PR TITLE
Add option to support non-error-first APIs

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,26 +10,42 @@ const processFn = (fn, opts) => function () {
 	}
 
 	return new P((resolve, reject) => {
-		args.push(function (err, result) {
-			if (opts.multiArgs) {
-				const results = new Array(arguments.length - 1);
+		if (opts.errorFirst) {
+			args.push(function (err, result) {
+				if (opts.multiArgs) {
+					const results = new Array(arguments.length - 1);
 
-				for (let i = 1; i < arguments.length; i++) {
-					results[i - 1] = arguments[i];
-				}
+					for (let i = 1; i < arguments.length; i++) {
+						results[i - 1] = arguments[i];
+					}
 
-				if (err) {
-					results.unshift(err);
-					reject(results);
+					if (err) {
+						results.unshift(err);
+						reject(results);
+					} else {
+						resolve(results);
+					}
+				} else if (err) {
+					reject(err);
 				} else {
-					resolve(results);
+					resolve(result);
 				}
-			} else if (err) {
-				reject(err);
-			} else {
-				resolve(result);
-			}
-		});
+			});
+		} else {
+			args.push(function (result) {
+				if (opts.multiArgs) {
+					const results = new Array(arguments.length - 1);
+
+					for (let i = 0; i < arguments.length; i++) {
+						results[i] = arguments[i];
+					}
+
+					resolve(results);
+				} else {
+					resolve(result);
+				}
+			});
+		}
 
 		fn.apply(that, args);
 	});
@@ -38,7 +54,8 @@ const processFn = (fn, opts) => function () {
 module.exports = (obj, opts) => {
 	opts = Object.assign({
 		exclude: [/.+(Sync|Stream)$/],
-		promiseModule: Promise
+		promiseModule: Promise,
+		errorFirst: true
 	}, opts);
 
 	const filter = key => {

--- a/readme.md
+++ b/readme.md
@@ -105,6 +105,13 @@ if (promiseFn()) {
 }
 ```
 
+##### errorFirst
+
+Type: `boolean`<br>
+Default: `true`
+
+Whether the callback has an error as the first argument. You'll want to set this to `false` if you're dealing with an API that doesn't have an error as the first argument, like `fs.exists()`, some browser APIs, Chrome Extension APIs, etc.
+
 ##### promiseModule
 
 Type: `Function`

--- a/test.js
+++ b/test.js
@@ -123,3 +123,22 @@ test('module support — function modules exclusion', t => {
 	t.is(typeof pModule.meow().then, 'function');
 	t.not(typeof pModule(() => {}).then, 'function');
 });
+
+test('`errorFirst` option', async t => {
+	const fixture = (foo, cb) => {
+		cb(foo);
+	};
+
+	t.is(await m(fixture, {errorFirst: false})('🦄'), '🦄');
+});
+
+test('`errorFirst` option and `multiArgs`', async t => {
+	const fixture = (foo, bar, cb) => {
+		cb(foo, bar);
+	};
+
+	t.deepEqual(await m(fixture, {
+		errorFirst: false,
+		multiArgs: true
+	})('🦄', '🌈'), ['🦄', '🌈']);
+});


### PR DESCRIPTION
Fixes #31 

Use this for review to ignore indentation changes:<br> https://github.com/sindresorhus/pify/pull/42/files?w=1

I'm not totally sold on the `errorFirst` option name. Any better suggestions?