### PR TITLE
Use native promisify utility when possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
+  - '8'
   - '6'
   - '4'


### PR DESCRIPTION
Opening to get the conversation started on leveraging native `promisify` when the executing process supports it. Updates use native `promisify` when available and none of the `pify` options imply functionality it cannot support. Performance testing may inform whether these changes are worth while or not.  

Resolves #41 

**Todo:**
- Investigate what is failing in the optimization-tests in Node 8. Initial glances indicate it could be an issue with v8-natives. Other tests are passing.
