### PR TITLE
use async so fn.constructor.name is AsyncFunction

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,6 @@
 
 const processFn = (fn, options) => function (...args) {
 	const P = options.promiseModule;
-	if (fn.constructor && fn.constructor.name === 'AsyncFunction') {
-		return fn(...args);
-	}
 
 	return new P(async (resolve, reject) => {
 		if (options.multiArgs) {
@@ -55,14 +52,14 @@ module.exports = (input, options) => {
 
 	let ret;
 	if (objType === 'function') {
-		ret = async (...args) => options.excludeMain ? input(...args) : processFn(input, options)(...args);
+		ret = async (...args) => (input.constructor !== undefined && input.constructor.name === 'AsyncFunction') || options.excludeMain ? input(...args) : processFn(input, options)(...args);
 	} else {
 		ret = Object.create(Object.getPrototypeOf(input));
 	}
 
 	for (const key in input) { // eslint-disable-line guard-for-in
 		const property = input[key];
-		ret[key] = typeof property === 'function' && filter(key) ? processFn(property, options) : property;
+		ret[key] = typeof property === 'function' && (property.constructor === undefined || property.constructor.name !== 'AsyncFunction') && filter(key) ? processFn(property, options) : property;
 	}
 
 	return ret;

--- a/index.js
+++ b/index.js
@@ -2,6 +2,9 @@
 
 const processFn = (fn, options) => function (...args) {
 	const P = options.promiseModule;
+	if (fn.constructor && fn.constructor.name === 'AsyncFunction') {
+		return fn(...args);
+	}
 
 	return new P(async (resolve, reject) => {
 		if (options.multiArgs) {

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const processFn = (fn, options) => function (...args) {
+const processFn = (fn, options) => async function (...args) {
 	const P = options.promiseModule;
 
-	return new P(async (resolve, reject) => {
+	return new P((resolve, reject) => {
 		if (options.multiArgs) {
 			args.push((...result) => {
 				if (options.errorFirst) {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const processFn = (fn, options) => function (...args) {
 	const P = options.promiseModule;
 
-	return new P((resolve, reject) => {
+	return new P(async (resolve, reject) => {
 		if (options.multiArgs) {
 			args.push((...result) => {
 				if (options.errorFirst) {
@@ -52,7 +52,7 @@ module.exports = (input, options) => {
 
 	let ret;
 	if (objType === 'function') {
-		ret = (...args) => options.excludeMain ? input(...args) : processFn(input, options)(...args);
+		ret = async (...args) => options.excludeMain ? input(...args) : processFn(input, options)(...args);
 	} else {
 		ret = Object.create(Object.getPrototypeOf(input));
 	}

--- a/test.js
+++ b/test.js
@@ -85,6 +85,14 @@ test('wrap core method', async t => {
 	t.is(JSON.parse(await m(fs.readFile)('package.json')).name, 'pify');
 });
 
+test('result is AsyncFunction', t => {
+	t.is(m(fs.readFile).constructor.name, 'AsyncFunction');
+});
+
+test('wrap twice still works', async t => {
+	t.is(JSON.parse(await m(m(fs.readFile))('package.json')).name, 'pify');
+});
+
 test('module support', async t => {
 	t.is(JSON.parse(await m(fs).readFile('package.json')).name, 'pify');
 });
@@ -150,7 +158,7 @@ test('module support — function modules exclusion', t => {
 	});
 
 	t.is(typeof pModule.meow().then, 'function');
-	t.not(typeof pModule(() => {}).then, 'function');
+	t.not(typeof pModule(() => {}).then, 'AsyncFunction');
 });
 
 test('`errorFirst` option', async t => {
@@ -269,3 +277,4 @@ test('class support - options.include over options.exclude', t => {
 	t.is(typeof pInstance.parentMethod1().then, 'function');
 	t.not(typeof pInstance.grandparentMethod1(() => {}).then, 'function');
 });
+

--- a/test.js
+++ b/test.js
@@ -93,6 +93,10 @@ test('wrap twice still works', async t => {
 	t.is(JSON.parse(await m(m(fs.readFile))('package.json')).name, 'pify');
 });
 
+test('wrap object then function still works', async t => {
+	t.is(JSON.parse(await m(m(fs).readFile)('package.json')).name, 'pify');
+});
+
 test('module support', async t => {
 	t.is(JSON.parse(await m(fs).readFile('package.json')).name, 'pify');
 });


### PR DESCRIPTION
This change does not affect behavior, but does allow for detection of functions that have already gone through pify. By returning an instance of AsyncFunction, the returned function's `constructor.name` property looks different from the one passed in.

A next step might be to check for instances of AsyncFunction and not pify them.