### PR TITLE
Remove unnecessary wrapper

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = (input, options) => {
 
 	let ret;
 	if (objType === 'function') {
-		ret = (...args) => options.excludeMain ? input(...args) : processFn(input, options)(...args);
+		ret = options.excludeMain ? input : processFn(input, options);
 	} else {
 		ret = Object.create(Object.getPrototypeOf(input));
 	}

--- a/optimization-test.js
+++ b/optimization-test.js
@@ -38,7 +38,7 @@ sut.unicorn().then(() => {
 	return sut.unicorn().then(() => {
 		assertOptimized(sut.unicorn, 'unicorn');
 	});
-}).catch(err => {
-	console.error(err.stack);
+}).catch(error => {
+	console.error(error.stack);
 	process.exit(1); // eslint-disable-line unicorn/no-process-exit
 });

--- a/test.js
+++ b/test.js
@@ -62,7 +62,7 @@ test('throw error on invalid input', t => {
 });
 
 test('error', async t => {
-	t.is(await m(fixture1)().catch(err => err), 'error');
+	t.is(await m(fixture1)().catch(error => error), 'error');
 });
 
 test('pass argument', async t => {
@@ -78,7 +78,7 @@ test('multiArgs option', async t => {
 });
 
 test('multiArgs option — rejection', async t => {
-	t.deepEqual(await m(fixture1, {multiArgs: true})().catch(err => err), ['error', 'unicorn', 'rainbow']);
+	t.deepEqual(await m(fixture1, {multiArgs: true})().catch(error => error), ['error', 'unicorn', 'rainbow']);
 });
 
 test('wrap core method', async t => {


### PR DESCRIPTION
`ret = (...args) => options.excludeMain ? input(...args) : processFn(input, options)(...args);`

can simplify as 

`ret = options.excludeMain ? input : processFn(input, options);`

PS: Using `err` in Promise catch will throw error in xo, So I rename it to `error`.