### PR TITLE
Add TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,200 @@
+type AnyFunction = (...args: any[]) => any;
+type CallbackError = Error | null | undefined;
+
+// Utility types
+
+type Last<T extends unknown[]> =
+	T extends [] ? never :
+	T extends [...infer _, infer R] ? R :
+	T extends [...infer _, (infer R)?] ? R | undefined:
+	never;
+
+type ExceptLast<T extends any[]> = T extends [ ...infer Head, any ] ? Head : any[];
+
+type LastParameter<T extends AnyFunction> = Last<Parameters<T>>;
+type ParametersExceptLast<T extends AnyFunction> = ExceptLast<Parameters<T>>;
+
+type SelectByOptionOr<O extends boolean, TTrue, TFalse> =
+	O extends true ? TTrue :
+	O extends false ? TFalse :
+	TTrue | TFalse;
+
+type Resolve<T> = [T][0];
+// End of utility types
+
+type CallbackSingleReturnType<
+	T extends AnyFunction,
+	TCb extends AnyFunction = LastParameter<T>,
+	TCbArgs = Parameters<Exclude<TCb, undefined>>
+> =
+	TCbArgs extends [CallbackError?] ? void :
+	TCbArgs extends [CallbackError, infer U] ? U :
+	TCbArgs extends any[] ? TCbArgs[1] extends undefined ? void : TCbArgs[1]:
+	never;
+
+type CallbackMultiReturnType<
+	T extends AnyFunction,
+	TCb extends AnyFunction = LastParameter<T>,
+	TCbArgs = Parameters<Exclude<TCb, undefined>>
+> =
+	TCbArgs extends [any, ... infer U] ? U :
+	TCbArgs extends [any?, ... infer U] ? U :
+	TCbArgs extends [any] ? [] :
+	TCbArgs extends [any?] ? [] :
+	TCbArgs extends [] ? [] :
+	never;
+
+type CallbackWithoutErrorSingleReturnType<T extends AnyFunction> = Parameters<LastParameter<T>> extends [] ? void : Parameters<LastParameter<T>>[0];
+
+type CallbackWithoutErrorMultiReturnType<T extends AnyFunction> = Parameters<LastParameter<T>>;
+
+type CallbackReturn<T extends AnyFunction, MultiArgs extends boolean, ErrorFirst extends boolean> = SelectByOptionOr<ErrorFirst,
+	SelectByOptionOr<MultiArgs, CallbackMultiReturnType<T>, CallbackSingleReturnType<T>>,
+	SelectByOptionOr<MultiArgs, CallbackWithoutErrorMultiReturnType<T>, CallbackWithoutErrorSingleReturnType<T>>>;
+
+type PifiedFunction<F extends AnyFunction, O extends PifyOptions> = Resolve<(...args:ParametersExceptLast<F>) => Promise<CallbackReturn<F, GetMultiArgs<O>, GetErrorFirst<O>>>>;
+
+type GetOption<O extends PifyOptions, Name extends string, Default extends boolean> =
+	O extends {[F in Name]: true} ? true :
+	O extends {[F in Name]: false} ? false :
+	O extends {[F in Name]: boolean} ? boolean :
+	O extends {[F in Name]: undefined} ? Default :
+	Default;
+type GetExcludeMain<O extends PifyOptions> = Resolve<GetOption<O, 'excludeMain', false>>;
+type GetErrorFirst<O extends PifyOptions> = Resolve<GetOption<O, 'errorFirst', true>>;
+type GetMultiArgs<O extends PifyOptions> = Resolve<GetOption<O, 'multiArgs', false>>;
+
+type PifiedObject<T, O extends PifyOptions> = Resolve<{
+	[Key in (keyof T)]: T[Key] extends AnyFunction ? PifiedFunction<T[Key], O> : T[Key];
+}>;
+
+type PifiedObjectFunction<T, O extends PifyOptions> = Resolve<
+	GetExcludeMain<O> extends true ?
+		T extends AnyFunction	?
+			({} extends T ? T & PifiedObject<T, O> : T) :
+			PifiedObject<T, O> :
+		T extends AnyFunction ?
+			LastParameter<T> extends never ? never : LastParameter<T> extends AnyFunction ?
+				({} extends T ? PifiedFunction<T, O> & PifiedObject<T, O> : PifiedFunction<T, O>) :
+				never :
+			PifiedObject<T, O>
+	>;
+
+interface PifyOptions {
+	/**
+	By default, the promisified function will only return the second argument from the callback, which works fine for most APIs. This option can be useful for modules like `request` that return multiple arguments. Turning this on will make it return an array of all arguments from the callback, excluding the error argument, instead of just the second argument. This also applies to rejections, where it returns an array of all the callback arguments, including the error.
+	@default false
+	@example
+	```
+	const request = require('request');
+	const pify = require('pify');
+	const pRequest = pify(request, {multiArgs: true});
+	(async () => {
+		const [httpResponse, body] = await pRequest('https://sindresorhus.com');
+	})();
+	```
+	*/
+	readonly multiArgs?: boolean,
+
+	/**
+	Methods in a module to promisfy. Remaining methods will be left untouched. Does not affect typescript compile time types.
+	*/
+	readonly include?: Array<string | RegExp>,
+
+	/**
+	Methods in a module not to promisify. Methods with names ending with 'Sync' are excluded by default. Does not the type of return value in compile time.
+	@default [/.+(Sync|Stream)$/]
+	*/
+	readonly exclude?: Array<string | RegExp>,
+
+	/**
+	If the given module is a function itself, it will be promisified. Enable this option if you want to promisify only methods of the module.
+	@default false
+	@example
+	```
+	const pify = require('pify');
+	function fn() {
+		return true;
+	}
+	fn.method = (data, callback) => {
+		setImmediate(() => {
+			callback(null, data);
+		});
+	};
+	(async () => {
+		// Promisify methods but not `fn()`
+		const promiseFn = pify(fn, {excludeMain: true});
+		if (promiseFn()) {
+			console.log(await promiseFn.method('hi'));
+		}
+	})();
+	```
+	*/
+	readonly excludeMain?: boolean,
+
+	/**
+	Whether the callback has an error as the first argument. You'll want to set this to false if you're dealing with an API that doesn't have an error as the first argument, like `fs.exists()`, some browser APIs, Chrome Extension APIs, etc.
+	@default true
+	*/
+	readonly errorFirst?: boolean,
+
+	/**
+	Custom promise module to use instead of the native one.
+	*/
+	readonly promiseModule?: PromiseConstructor
+}
+
+interface PifyOptionsMultiArgs0ErrorFirst1 extends PifyOptions {
+	multiArgs?: false | undefined;
+	errorFirst?: true | undefined;
+	excludeMain: false | undefined;
+}
+interface PifyOptionsMultiArgs0ErrorFirst0 extends PifyOptions {
+	multiArgs?: false | undefined;
+	errorFirst: false;
+	excludeMain: false | undefined;
+}
+interface PifyOptionsMultiArgs1ErrorFirst1 extends PifyOptions {
+	multiArgs: true;
+	errorFirst?: true | undefined;
+	excludeMain: false | undefined;
+}
+interface PifyOptionsMultiArgs1ErrorFirst0 extends PifyOptions {
+	multiArgs: true;
+	errorFirst: false;
+	excludeMain: false | undefined;
+}
+
+/**
+Returns a `Promise` wrapped version of the supplied function or module.
+@param input - Callback-style function or module whose methods you want to promisify.
+@returns Wrapped version of the supplied function or module.
+@example
+```
+const fs = require('fs');
+const pify = require('pify');
+(async () => {
+	// Promisify a single function
+	const data = await pify(fs.readFile)('package.json', 'utf8');
+	console.log(JSON.parse(data).name);
+	//=> 'pify'
+	// Promisify all methods in a module
+	const data2 = await pify(fs).readFile('package.json', 'utf8');
+	console.log(JSON.parse(data2).name);
+	//=> 'pify'
+})();
+```
+*/
+declare function pify<Options extends PifyOptionsMultiArgs1ErrorFirst0, AT extends any[]>(fn:(...args:[...AT, () => any]) => any, options:Options): (...args:[...AT]) => Promise<[]>;
+declare function pify<Options extends PifyOptionsMultiArgs0ErrorFirst0, AT extends any[]>(fn:(...args:[...AT, () => any]) => any, options:Options): (...args:[...AT]) => Promise<void>;
+declare function pify<Options extends PifyOptionsMultiArgs1ErrorFirst1, AT extends any[]>(fn:(...args:[...AT, (error: CallbackError) => any]) => any, options:Options): (...args:[...AT]) => Promise<[]>;
+declare function pify<Options extends PifyOptionsMultiArgs0ErrorFirst1, AT extends any[]>(fn:(...args:[...AT, (error: CallbackError) => any]) => any, options:Options): (...args:[...AT]) => Promise<void>;
+declare function pify<Options extends PifyOptionsMultiArgs1ErrorFirst0, AT extends any[], RT1 extends any, RT extends any[]>(fn:(...args:[...AT, (...returns:[RT1, ...RT]) => any]) => any, options:Options): (...args:[...AT]) => Promise<RT>;
+declare function pify<Options extends PifyOptionsMultiArgs0ErrorFirst0, AT extends any[], RT1 extends any, RT extends any[]>(fn:(...args:[...AT, (...returns:[RT1, ...RT]) => any]) => any, options:Options): (...args:[...AT]) => Promise<RT1>;
+declare function pify<Options extends PifyOptionsMultiArgs1ErrorFirst1, AT extends any[], RT1 extends any, RT extends any[]>(fn:(...args:[...AT, (error: CallbackError, ...returns:[RT1, ...RT]) => any]) => any, options:Options): (...args:[...AT]) => Promise<[RT1, ...RT]>;
+declare function pify<Options extends PifyOptionsMultiArgs0ErrorFirst1, AT extends any[], RT1 extends any, RT extends any[]>(fn:(...args:[...AT, (error: CallbackError, ...returns:[RT1, ...RT]) => any]) => any, options:Options): (...args:[...AT]) => Promise<RT1>;
+declare function pify<AT extends any[], RT1 extends any, RT extends any[]>(fn:(...args:[...AT, (error: CallbackError, ...returns:[RT1, ...RT]) => any]) => any): (...args:[...AT]) => Promise<RT1>;
+declare function pify<AT extends any[]>(fn:(...args:[...AT, (error: CallbackError) => any]) => any): (...args:[...AT]) => Promise<void>;
+declare function pify<T extends Function | object, Options extends PifyOptions>(fn: T, options?: Options): PifiedObjectFunction<T, Options>;
+
+export = pify;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,152 @@
+import {expectType, expectNotType, expectError, expectAssignable, printType} from 'tsd';
+import pify = require('.');
+
+expectError(pify());
+expectError(pify(null));
+expectError(pify(undefined));
+expectError(pify(123));
+expectError(pify('abc'));
+expectError(pify(null, {}));
+expectError(pify(undefined, {}));
+expectError(pify(123, {}));
+expectError(pify('abc', {}));
+expectError(pify((v: number) => {})());
+
+type A1 = 'A1';
+type A2 = 'A2';
+type R1 = 'R1';
+type R2 = 'R2';
+let someBoolean:boolean = Math.random() > 0.5;
+const a1:A1 = 'A1';
+const a2:A2 = 'A2';
+
+let function00 = (cb: (err: Error | undefined) => any) => { };
+let function10 = (a1:A1, cb: (err: Error | undefined) => any) => { };
+let function20 = (a1:A1, a2:A2, cb: (err: Error | undefined) => any) => { };
+
+let function01 = (cb: (err: Error | undefined, v1?:R1) => any) => { };
+let function11 = (a1:A1, cb: (err: Error | undefined, v1?:R1) => any) => { };
+let function21 = (a1:A1, a2:A2, cb: (err: Error | undefined, v1?:R1) => any) => { };
+
+let function02 = (cb: (err: Error | undefined, v1?:R1, v2?:R2) => any) => { };
+let function12 = (a1:A1, cb: (err: Error | undefined, v1?:R1, v2?:R2) => any) => { };
+let function22 = (a1:A1, a2:A2, cb: (err: Error | undefined, v1?:R1, v2?:R2) => any) => { };
+
+let functionNoError00 = (cb: () => any) => { };
+let functionNoError10 = (a1:A1, cb: () => any) => { };
+let functionNoError01 = (cb: (v1:R1) => any) => { };
+let functionNoError11 = (a1:A1, cb: (v1:R1) => any) => { };
+
+expectType<() => Promise<void>>(pify(functionNoError00, {errorFirst: false}));
+expectType<() => Promise<R1>>(pify(functionNoError01, {errorFirst: false}));
+expectType<(a1:A1) => Promise<void>>(pify(functionNoError10, {errorFirst: false}));
+expectType<(a1:A1) => Promise<R1>>(pify(functionNoError11, {errorFirst: false}));
+
+expectType<{}>(pify({}));
+expectAssignable<{a: number, b: boolean, c: string}>(pify({a: 1, b: true, c: 'qwe'}));
+expectType<{a: number, b: boolean, c: string}>(pify({a: 1, b: someBoolean, c: 'qwe'}));
+
+expectType<() => Promise<void>>(pify(function00));
+expectType<(a1:A1) => Promise<void>>(pify(function10));
+expectType<(a1:A1, a2:A2) => Promise<void>>(pify(function20));
+
+expectType<() => Promise<void>>(pify(function00, {excludeMain: false}));
+expectType<(a1:A1) => Promise<void>>(pify(function10, {excludeMain: false}));
+expectType<(a1:A1, a2:A2) => Promise<void>>(pify(function20, {excludeMain: false}));
+
+expectType<() => Promise<void>>(pify(function00, {errorFirst: true}));
+expectType<(a1:A1) => Promise<void>>(pify(function10, {errorFirst: true}));
+expectType<(a1:A1, a2:A2) => Promise<void>>(pify(function20, {errorFirst: true}));
+
+expectType<() => Promise<Error | undefined>>(pify(function00, {errorFirst: false}));
+expectType<(a1:A1) => Promise<Error | undefined>>(pify(function10, {errorFirst: false}));
+expectType<(a1:A1, a2:A2) => Promise<Error | undefined>>(pify(function20, {errorFirst: false}));
+
+expectType<() => Promise<void>>(pify(function00, {errorFirst: true}));
+expectType<(a1:A1) => Promise<void>>(pify(function10, {errorFirst: true}));
+expectType<(a1:A1, a2:A2) => Promise<void>>(pify(function20, {errorFirst: true}));
+
+expectType<() => Promise<[Error | undefined]>>(pify(function00, {errorFirst: false, multiArgs: true}));
+expectType<(a1:A1) => Promise<[Error | undefined]>>(pify(function10, {errorFirst: false, multiArgs: true}));
+expectType<(a1:A1, a2:A2) => Promise<[Error | undefined]>>(pify(function20, {errorFirst: false, multiArgs: true}));
+
+expectType<typeof function00>(pify(function00, {excludeMain: true}));
+expectType<typeof function10>(pify(function10, {excludeMain: true}));
+expectType<typeof function20>(pify(function20, {excludeMain: true}));
+expectType<typeof function01>(pify(function01, {excludeMain: true}));
+expectType<typeof function11>(pify(function11, {excludeMain: true}));
+expectType<typeof function21>(pify(function21, {excludeMain: true}));
+expectType<typeof function02>(pify(function02, {excludeMain: true}));
+expectType<typeof function12>(pify(function12, {excludeMain: true}));
+expectType<typeof function22>(pify(function22, {excludeMain: true}));
+
+expectAssignable<Function>(pify(function00, {excludeMain: someBoolean}));
+expectAssignable<Function>(pify(function01, {excludeMain: someBoolean}));
+expectAssignable<Function>(pify(function02, {excludeMain: someBoolean}));
+expectAssignable<Function>(pify(function10, {excludeMain: someBoolean}));
+expectAssignable<Function>(pify(function11, {excludeMain: someBoolean}));
+expectAssignable<Function>(pify(function12, {excludeMain: someBoolean}));
+expectAssignable<Function>(pify(function20, {excludeMain: someBoolean}));
+expectAssignable<Function>(pify(function21, {excludeMain: someBoolean}));
+expectAssignable<Function>(pify(function22, {excludeMain: someBoolean}));
+
+expectType<{
+	function: () => Promise<void>,
+	number: number,
+}>(pify({
+	function: function00,
+	number: 123,
+}));
+
+expectAssignable<{
+	function: () => Promise<void>,
+	number: number,
+	string?: string,
+}>(pify({
+	function: function00,
+	number: 1,
+}));
+
+expectNotType<{
+	function: () => Promise<void>,
+	string: string,
+	number: number,
+}>(pify({
+	function: function00,
+	string: 'qwe',
+}));
+
+declare function generic10<A0>(a0:A0, cb:(error: Error | null | undefined) => any): any;
+declare function generic01<R0>(cb:(error:  Error | null | undefined, r0:R0) => any): any;
+declare function generic11<A0, R0>(a0:A0, cb:(error:  Error | null | undefined, r0:R0) => any): any;
+
+expectType<Promise<A1>>((pify(generic01))<A1>());
+expectType<Promise<void>>((pify(generic10))<A1>(a1));
+expectType<Promise<A2>>((pify(generic11))<A1, A2>(a1));
+
+declare function realLifeFunction1(url: string, callback: (error?: Error | null | undefined, response?: { statusCode: number }, body?: string) => void): void;
+expectType<(url: string) => Promise<[{ statusCode: number }?, string?]>>(pify(realLifeFunction1, { multiArgs: true }))
+declare function realLifeFunction2(url: string, callback: (response?: { statusCode: number }, body?: string) => void): void;
+expectType<(url: string) => Promise<[{ statusCode: number }?, string?]>>(pify(realLifeFunction2, { multiArgs: true, errorFirst: false }))
+
+const fs = {
+		readFile(path: string, callback: (error?: Error, data?: Buffer) => void): void {
+				callback(undefined, Buffer.from('abc', 'utf8'));
+		},
+		exists(path: string, callback: (result: boolean) => void): void {
+				callback(true);
+		},
+};
+
+expectType<{
+	readFile: (path: string) => Promise<Buffer | undefined>,
+	exists: (path: string) => Promise<void>,
+}>(pify(fs));
+
+expectAssignable<{
+	readFile: (path: string) => Promise<Buffer | undefined>,
+}>(pify(fs, {exclude:['exists']}));
+
+expectAssignable<{
+	exists: (path: string) => Promise<boolean>,
+}>(pify(fs, {exclude:['readFile'], errorFirst:false}));

--- a/package.json
+++ b/package.json
@@ -14,11 +14,12 @@
 		"node": ">=10"
 	},
 	"scripts": {
-		"test": "xo && ava",
+		"test": "xo && ava && tsd",
 		"optimization-test": "node --allow-natives-syntax optimization-test.js"
 	},
 	"files": [
-		"index.js"
+		"index.js",
+		"index.d.ts"
 	],
 	"keywords": [
 		"promisify",
@@ -43,6 +44,7 @@
 	"devDependencies": {
 		"ava": "^2.4.0",
 		"pinkie-promise": "^2.0.0",
+		"tsd": "^0.17.0",
 		"v8-natives": "^1.1.0",
 		"xo": "^0.26.1"
 	}


### PR DESCRIPTION
Solves #74

- works with generics(up to 6 arguments and 5 returned values)
- works with anything except generics for any number of arguments
- doesn't use `include` and `exclude` for typing, as we can't test RegExp while typing

<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#74: Add TypeScript type definition](https://issuehunt.io/repos/41585934/issues/74)
---
</details>
<!-- /Issuehunt content-->