### PR TITLE
Add TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,30 @@
+type Last<T extends readonly unknown[]> = T extends [...any, infer L]
+	? L
+	: never;
+type DropLast<T extends readonly unknown[]> = T extends [...(infer U), any]
+	? U
+	: [];
+
+interface Options {
+	multiArgs: boolean;
+}
+
+type Promisify<TArgs extends readonly unknown[], TOptions extends Options> = (
+	...args: DropLast<TArgs>
+) => Last<TArgs> extends (...args: any) => any
+	? Promise<
+			TOptions extends { multiArgs: false }
+				? Last<Parameters<Last<TArgs>>>
+				: Parameters<Last<TArgs>>
+	  >
+	: never;
+
+declare function pify<
+	TArgs extends readonly unknown[],
+	TOptions extends Options = { multiArgs: false }
+>(
+	input: (...args: TArgs) => any,
+	options?: TOptions
+): Promisify<TArgs, TOptions>;
+
+export = pify;

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,12 +9,13 @@ type DropLast<T extends readonly unknown[]> = T extends [...(infer U), any]
 
 type StringEndsWith<S, X extends string> = S extends `${infer _}${X}` ? true : false;
 
-interface Options<Includes extends readonly unknown[], Excludes extends readonly unknown[], MultiArgs extends boolean = false, ErrorFirst extends boolean = true> {
+interface Options<Includes extends readonly unknown[], Excludes extends readonly unknown[], MultiArgs extends boolean = false, ErrorFirst extends boolean = true, ExcludeMain extends boolean = false> {
 	multiArgs?: MultiArgs;
 	include?: Includes;
 	exclude?: Excludes;
 	errorFirst?: ErrorFirst;
 	promiseModule?: PromiseConstructor;
+	excludeMain?: ExcludeMain;
 }
 
 interface InternalOptions<Includes extends readonly unknown[], Excludes extends readonly unknown[], MultiArgs extends boolean = false, ErrorFirst extends boolean = true> {
@@ -73,7 +74,7 @@ declare function pify<
 >(
 	// eslint-disable-next-line unicorn/prefer-module
 	module: Module,
-	options?: Options<Includes, Excludes, MultiArgs, ErrorFirst>
+	options?: Options<Includes, Excludes, MultiArgs, ErrorFirst, true>
 ): PromisifyModule<Module, MultiArgs, ErrorFirst, Includes, Excludes>;
 
 export = pify;

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,7 @@ interface Options<Includes extends readonly unknown[], Excludes extends readonly
 	include?: Includes;
 	exclude?: Excludes;
 	errorFirst?: ErrorFirst;
+	promiseModule?: PromiseConstructor;
 }
 
 interface InternalOptions<Includes extends readonly unknown[], Excludes extends readonly unknown[], MultiArgs extends boolean = false, ErrorFirst extends boolean = true> {
@@ -28,6 +29,7 @@ type Promisify<Args extends readonly unknown[], GenericOptions extends InternalO
 	...args: DropLast<Args>
 ) =>
 Last<Args> extends (...args: any) => any
+  // For single-argument functions when errorFirst: true we just return Promise<unknown> as it will always reject.
 	? Parameters<Last<Args>> extends [infer SingleCallbackArg] ? GenericOptions extends { errorFirst: true } ? Promise<unknown> : Promise<SingleCallbackArg>
 	: Promise<
 	GenericOptions extends {multiArgs: false}

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,18 +24,17 @@ interface InternalOptions<Includes extends readonly unknown[], Excludes extends 
 	errorFirst: ErrorFirst;
 }
 
-
 type Promisify<Args extends readonly unknown[], GenericOptions extends InternalOptions<readonly unknown[], readonly unknown[], boolean, boolean>> = (
 	...args: DropLast<Args>
 ) =>
 Last<Args> extends (...args: any) => any
-  // For single-argument functions when errorFirst: true we just return Promise<unknown> as it will always reject.
-	? Parameters<Last<Args>> extends [infer SingleCallbackArg] ? GenericOptions extends { errorFirst: true } ? Promise<unknown> : Promise<SingleCallbackArg>
-	: Promise<
-	GenericOptions extends {multiArgs: false}
-		? Last<Parameters<Last<Args>>>
-		: Parameters<Last<Args>>
-	>
+// For single-argument functions when errorFirst: true we just return Promise<unknown> as it will always reject.
+	? Parameters<Last<Args>> extends [infer SingleCallbackArg] ? GenericOptions extends {errorFirst: true} ? Promise<unknown> : Promise<SingleCallbackArg>
+		: Promise<
+		GenericOptions extends {multiArgs: false}
+			? Last<Parameters<Last<Args>>>
+			: Parameters<Last<Args>>
+		>
 	: never;
 
 type PromisifyModule<

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,8 @@ Last<Args> extends (...args: any) => any
 			? Last<Parameters<Last<Args>>>
 			: Parameters<Last<Args>>
 		>
-	: never;
+	// Functions without a callback will return a promise that never settles. We model this as Promise<unknown>
+	: Promise<unknown>;
 
 type PromisifyModule<
 	Module extends Record<string, any>,

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,10 @@ type Promisify<TArgs extends readonly unknown[], TOptions extends Options> = (
 	  >
 	: never;
 
+type PromisifyModule<TModule extends { [key: string]: any }, TOptions extends Options> = {
+	[K in keyof TModule]: TModule[K] extends (...args: infer TArgs) => any ? Promisify<TArgs, TOptions> : never;
+}
+
 declare function pify<
 	TArgs extends readonly unknown[],
 	TOptions extends Options = { multiArgs: false }
@@ -26,5 +30,12 @@ declare function pify<
 	input: (...args: TArgs) => any,
 	options?: TOptions
 ): Promisify<TArgs, TOptions>;
+declare function pify<
+	TModule extends { [key: string]: any },
+	TOptions extends Options = { multiArgs: false }
+>(
+	module: TModule,
+	options?: TOptions
+): PromisifyModule<TModule, TOptions>;
 
 export = pify;

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,22 +9,27 @@ type DropLast<T extends readonly unknown[]> = T extends [...(infer U), any]
 
 type StringEndsWith<S, X extends string> = S extends `${infer _}${X}` ? true : false;
 
-interface Options<Includes extends readonly unknown[], Excludes extends readonly unknown[], MultiArgs extends boolean = false> {
+interface Options<Includes extends readonly unknown[], Excludes extends readonly unknown[], MultiArgs extends boolean = false, ErrorFirst extends boolean = true> {
 	multiArgs?: MultiArgs;
 	include?: Includes;
 	exclude?: Excludes;
+	errorFirst?: ErrorFirst;
 }
 
-interface InternalOptions<Includes extends readonly unknown[], Excludes extends readonly unknown[], MultiArgs extends boolean = false> {
+interface InternalOptions<Includes extends readonly unknown[], Excludes extends readonly unknown[], MultiArgs extends boolean = false, ErrorFirst extends boolean = true> {
 	multiArgs: MultiArgs;
 	include: Includes;
 	exclude: Excludes;
+	errorFirst: ErrorFirst;
 }
 
-type Promisify<Args extends readonly unknown[], GenericOptions extends InternalOptions<readonly unknown[], readonly unknown[], boolean>> = (
+
+type Promisify<Args extends readonly unknown[], GenericOptions extends InternalOptions<readonly unknown[], readonly unknown[], boolean, boolean>> = (
 	...args: DropLast<Args>
-) => Last<Args> extends (...args: any) => any
-	? Promise<
+) =>
+Last<Args> extends (...args: any) => any
+	? Parameters<Last<Args>> extends [infer SingleCallbackArg] ? GenericOptions extends { errorFirst: true } ? Promise<unknown> : Promise<SingleCallbackArg>
+	: Promise<
 	GenericOptions extends {multiArgs: false}
 		? Last<Parameters<Last<Args>>>
 		: Parameters<Last<Args>>
@@ -34,6 +39,7 @@ type Promisify<Args extends readonly unknown[], GenericOptions extends InternalO
 type PromisifyModule<
 	Module extends Record<string, any>,
 	MultiArgs extends boolean,
+	ErrorFirst extends boolean,
 	Includes extends ReadonlyArray<keyof Module>,
 	Excludes extends ReadonlyArray<keyof Module>,
 > = {
@@ -44,7 +50,7 @@ type PromisifyModule<
 				? Module[K]
 				: StringEndsWith<K, 'Sync' | 'Stream'> extends true
 					? Module[K]
-					: Promisify<Args, InternalOptions<Includes, Excludes, MultiArgs>>
+					: Promisify<Args, InternalOptions<Includes, Excludes, MultiArgs, ErrorFirst>>
 		: Module[K];
 };
 
@@ -52,19 +58,21 @@ declare function pify<
 	FirstArg,
 	Args extends readonly unknown[],
 	MultiArgs extends boolean = false,
+	ErrorFirst extends boolean = true,
 >(
 	input: (arg: FirstArg, ...args: Args) => any,
-	options?: Options<[], [], MultiArgs>
-): Promisify<[FirstArg, ...Args], InternalOptions<[], [], MultiArgs>>;
+	options?: Options<[], [], MultiArgs, ErrorFirst>
+): Promisify<[FirstArg, ...Args], InternalOptions<[], [], MultiArgs, ErrorFirst>>;
 declare function pify<
 	Module extends Record<string, any>,
 	Includes extends ReadonlyArray<keyof Module> = [],
 	Excludes extends ReadonlyArray<keyof Module> = [],
 	MultiArgs extends boolean = false,
+	ErrorFirst extends boolean = true,
 >(
 	// eslint-disable-next-line unicorn/prefer-module
 	module: Module,
-	options?: Options<Includes, Excludes, MultiArgs>
-): PromisifyModule<Module, MultiArgs, Includes, Excludes>;
+	options?: Options<Includes, Excludes, MultiArgs, ErrorFirst>
+): PromisifyModule<Module, MultiArgs, ErrorFirst, Includes, Excludes>;
 
 export = pify;

--- a/index.d.ts
+++ b/index.d.ts
@@ -49,12 +49,13 @@ type PromisifyModule<
 };
 
 declare function pify<
+	FirstArg,
 	Args extends readonly unknown[],
 	MultiArgs extends boolean = false,
 >(
-	input: (...args: Args) => any,
+	input: (arg: FirstArg, ...args: Args) => any,
 	options?: Options<[], [], MultiArgs>
-): Promisify<Args, InternalOptions<[], [], MultiArgs>>;
+): Promisify<[FirstArg, ...Args], InternalOptions<[], [], MultiArgs>>;
 declare function pify<
 	Module extends Record<string, any>,
 	Includes extends ReadonlyArray<keyof Module> = [],

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -159,3 +159,13 @@ moduleFunction.method = function (_cb: (error: Error, value: string) => void): v
 expectType<Promise<number>>(pify(moduleFunction)());
 
 expectType<Promise<string>>(pify(moduleFunction, {excludeMain: true}).method());
+
+// Classes
+
+declare class MyClass {
+	method1(cb: (error: Error, value: string) => void): void;
+	method2(arg: number, cb: (error: Error, value: number) => void): void;
+}
+
+expectType<Promise<string>>(pify(new MyClass()).method1());
+expectType<Promise<number>>(pify(new MyClass()).method2(4));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
-import { expectError, expectType } from "tsd";
+import { expectError, expectType, printType } from "tsd";
 import pify = require(".");
 
 expectError(pify());
@@ -12,6 +12,8 @@ expectError(pify(123, {}));
 expectError(pify("abc", {}));
 
 expectType<never>(pify((v: number) => {})());
+// TODO: Figure out a way for this to return `never`
+expectType<Promise<never>>(pify(() => 'hello')());
 
 // callback with 0 additional params
 declare function fn0(fn: (val: number) => void): void;
@@ -94,3 +96,15 @@ declare function overloaded(value: string, cb: (value: string) => void): void;
 // Chooses last overload
 // See https://github.com/microsoft/TypeScript/issues/32164
 expectType<Promise<string>>(pify(overloaded)(""));
+
+declare const fixtureModule: {
+	method1: (arg: string, cb: (error: Error, value: string) => void) => void;
+	method2: (arg: number, cb: (error: Error, value: number) => void) => void;
+	method3: (arg: string) => string
+}
+
+// module support
+expectType<Promise<string>>(pify(fixtureModule).method1(""));
+expectType<Promise<number>>(pify(fixtureModule).method2(0));
+// Same semantics as pify(fn)
+expectType<never>(pify(fixtureModule).method3());

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -101,9 +101,11 @@ declare const fixtureModule: {
 	method1: (arg: string, cb: (error: Error, value: string) => void) => void;
 	method2: (arg: number, cb: (error: Error, value: number) => void) => void;
 	method3: (arg: string) => string
+	prop: number;
 }
 
 // module support
+expectType<number>(pify(fixtureModule).prop);
 expectType<Promise<string>>(pify(fixtureModule).method1(""));
 expectType<Promise<number>>(pify(fixtureModule).method2(0));
 // Same semantics as pify(fn)

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -12,8 +12,8 @@ expectError(pify(123, {}));
 expectError(pify('abc', {}));
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
-expectType<never>(pify((v: number) => {})());
-expectType<never>(pify(() => 'hello')());
+expectType<Promise<unknown>>(pify((v: number) => {})());
+expectType<Promise<unknown>>(pify(() => 'hello')());
 
 // Callback with 1 additional params
 declare function fn1(x: number, fn: (error: Error, value: number) => void): void;
@@ -108,7 +108,7 @@ expectType<number>(pify(fixtureModule).prop);
 expectType<Promise<string>>(pify(fixtureModule).method1(''));
 expectType<Promise<number>>(pify(fixtureModule).method2(0));
 // Same semantics as pify(fn)
-expectType<never>(pify(fixtureModule).method3());
+expectType<Promise<unknown>>(pify(fixtureModule).method3());
 
 // Excludes
 expectType<

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -148,3 +148,14 @@ expectType<Promise<[number, string]>>(
 expectType<Promise<[number, string]>>(
 	pify(callback22, {multiArgs: true, errorFirst: false})('a', 'b'),
 );
+
+// Module function
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+function moduleFunction(_cb: (error: Error, value: number) => void): void {}
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+moduleFunction.method = function (_cb: (error: Error, value: string) => void): void {};
+
+expectType<Promise<number>>(pify(moduleFunction)());
+
+expectType<Promise<string>>(pify(moduleFunction, {excludeMain: true}).method());

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -16,16 +16,16 @@ expectType<never>(pify((v: number) => {})());
 expectType<never>(pify(() => 'hello')());
 
 // Callback with 1 additional params
-declare function fn1(x: number, fn: (err: Error, value: number) => void): void;
+declare function fn1(x: number, fn: (error: Error, value: number) => void): void;
 expectType<Promise<number>>(pify(fn1)(1));
 
 // Callback with 2 additional params
-declare function fn2(x: number, y: number, fn: (err: Error, value: number) => void): void;
+declare function fn2(x: number, y: number, fn: (error: Error, value: number) => void): void;
 expectType<Promise<number>>(pify(fn2)(1, 2));
 
 // Generics
 
-declare function generic<T>(value: T, fn: (err: Error, value: T) => void): void;
+declare function generic<T>(value: T, fn: (error: Error, value: T) => void): void;
 declare const genericValue: 'hello' | 'goodbye';
 expectType<Promise<typeof genericValue>>(pify(generic)(genericValue));
 
@@ -40,7 +40,7 @@ declare function generic10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
 	value8: T8,
 	value9: T9,
 	value10: T10,
-	cb: (err: Error, value: {
+	cb: (error: Error, value: {
 		val1: T1;
 		val2: T2;
 		val3: T3;
@@ -86,8 +86,8 @@ expectType<Promise<[number, string]>>(
 );
 
 // Overloads
-declare function overloaded(value: number, cb: (err: Error, value: number) => void): void;
-declare function overloaded(value: string, cb: (err: Error,value: string) => void): void;
+declare function overloaded(value: number, cb: (error: Error, value: number) => void): void;
+declare function overloaded(value: string, cb: (error: Error, value: string) => void): void;
 
 // Chooses last overload
 // See https://github.com/microsoft/TypeScript/issues/32164
@@ -132,15 +132,15 @@ expectType<
 (arg: 'sync') => Promise<'sync'>
 >(pify(fixtureModule, {include: ['callbackEndingInSync']}).callbackEndingInSync);
 
-// errorFirst option:
+// Option errorFirst:
 
 declare function fn0(fn: (value: number) => void): void;
 
 // Unknown as it returns a promise that always rejects because errorFirst = true
 expectType<Promise<unknown>>(pify(fn0)());
-expectType<Promise<unknown>>(pify(fn0, { errorFirst: true })());
+expectType<Promise<unknown>>(pify(fn0, {errorFirst: true})());
 
-expectType<Promise<number>>(pify(fn0, { errorFirst: false })());
+expectType<Promise<number>>(pify(fn0, {errorFirst: false})());
 expectType<Promise<[number, string]>>(pify(callback02, {multiArgs: true, errorFirst: true})());
 expectType<Promise<[number, string]>>(
 	pify(callback12, {multiArgs: true, errorFirst: false})('a'),

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -15,21 +15,17 @@ expectError(pify('abc', {}));
 expectType<never>(pify((v: number) => {})());
 expectType<never>(pify(() => 'hello')());
 
-// Callback with 0 additional params
-declare function fn0(fn: (value: number) => void): void;
-expectType<Promise<number>>(pify(fn0)());
-
 // Callback with 1 additional params
-declare function fn1(x: number, fn: (value: number) => void): void;
+declare function fn1(x: number, fn: (err: Error, value: number) => void): void;
 expectType<Promise<number>>(pify(fn1)(1));
 
 // Callback with 2 additional params
-declare function fn2(x: number, y: number, fn: (value: number) => void): void;
+declare function fn2(x: number, y: number, fn: (err: Error, value: number) => void): void;
 expectType<Promise<number>>(pify(fn2)(1, 2));
 
 // Generics
 
-declare function generic<T>(value: T, fn: (value: T) => void): void;
+declare function generic<T>(value: T, fn: (err: Error, value: T) => void): void;
 declare const genericValue: 'hello' | 'goodbye';
 expectType<Promise<typeof genericValue>>(pify(generic)(genericValue));
 
@@ -44,7 +40,7 @@ declare function generic10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
 	value8: T8,
 	value9: T9,
 	value10: T10,
-	cb: (value: {
+	cb: (err: Error, value: {
 		val1: T1;
 		val2: T2;
 		val3: T3;
@@ -90,8 +86,8 @@ expectType<Promise<[number, string]>>(
 );
 
 // Overloads
-declare function overloaded(value: number, cb: (value: number) => void): void;
-declare function overloaded(value: string, cb: (value: string) => void): void;
+declare function overloaded(value: number, cb: (err: Error, value: number) => void): void;
+declare function overloaded(value: string, cb: (err: Error,value: string) => void): void;
 
 // Chooses last overload
 // See https://github.com/microsoft/TypeScript/issues/32164
@@ -135,3 +131,20 @@ expectType<
 expectType<
 (arg: 'sync') => Promise<'sync'>
 >(pify(fixtureModule, {include: ['callbackEndingInSync']}).callbackEndingInSync);
+
+// errorFirst option:
+
+declare function fn0(fn: (value: number) => void): void;
+
+// Unknown as it returns a promise that always rejects because errorFirst = true
+expectType<Promise<unknown>>(pify(fn0)());
+expectType<Promise<unknown>>(pify(fn0, { errorFirst: true })());
+
+expectType<Promise<number>>(pify(fn0, { errorFirst: false })());
+expectType<Promise<[number, string]>>(pify(callback02, {multiArgs: true, errorFirst: true})());
+expectType<Promise<[number, string]>>(
+	pify(callback12, {multiArgs: true, errorFirst: false})('a'),
+);
+expectType<Promise<[number, string]>>(
+	pify(callback22, {multiArgs: true, errorFirst: false})('a', 'b'),
+);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,49 +1,50 @@
-import { expectError, expectType, printType } from "tsd";
-import pify = require(".");
+import {expectError, expectType, printType} from 'tsd';
+import pify from '.';
 
 expectError(pify());
 expectError(pify(null));
 expectError(pify(undefined));
 expectError(pify(123));
-expectError(pify("abc"));
+expectError(pify('abc'));
 expectError(pify(null, {}));
 expectError(pify(undefined, {}));
 expectError(pify(123, {}));
-expectError(pify("abc", {}));
+expectError(pify('abc', {}));
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
 expectType<never>(pify((v: number) => {})());
 // TODO: Figure out a way for this to return `never`
 expectType<Promise<never>>(pify(() => 'hello')());
 
-// callback with 0 additional params
-declare function fn0(fn: (val: number) => void): void;
+// Callback with 0 additional params
+declare function fn0(fn: (value: number) => void): void;
 expectType<Promise<number>>(pify(fn0)());
 
-// callback with 1 additional params
-declare function fn1(x: number, fn: (val: number) => void): void;
+// Callback with 1 additional params
+declare function fn1(x: number, fn: (value: number) => void): void;
 expectType<Promise<number>>(pify(fn1)(1));
 
-// callback with 2 additional params
-declare function fn2(x: number, y: number, fn: (val: number) => void): void;
+// Callback with 2 additional params
+declare function fn2(x: number, y: number, fn: (value: number) => void): void;
 expectType<Promise<number>>(pify(fn2)(1, 2));
 
-// generics
+// Generics
 
-declare function generic<T>(val: T, fn: (val: T) => void): void;
-declare const genericVal: "hello" | "goodbye";
-expectType<Promise<typeof genericVal>>(pify(generic)(genericVal));
+declare function generic<T>(value: T, fn: (value: T) => void): void;
+declare const genericValue: 'hello' | 'goodbye';
+expectType<Promise<typeof genericValue>>(pify(generic)(genericValue));
 
 declare function generic10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
-	val1: T1,
-	val2: T2,
-	val3: T3,
-	val4: T4,
-	val5: T5,
-	val6: T6,
-	val7: T7,
-	val8: T8,
-	val9: T9,
-	val10: T10,
+	value1: T1,
+	value2: T2,
+	value3: T3,
+	value4: T4,
+	value5: T5,
+	value6: T6,
+	value7: T7,
+	value8: T8,
+	value9: T9,
+	value10: T10,
 	cb: (value: {
 		val1: T1;
 		val2: T2;
@@ -58,44 +59,44 @@ declare function generic10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
 	}) => void
 ): void;
 expectType<
-	Promise<{
-		val1: 1;
-		val2: 2;
-		val3: 3;
-		val4: 4;
-		val5: 5;
-		val6: 6;
-		val7: 7;
-		val8: "8";
-		val9: 9;
-		val10: 10;
-	}>
->(pify(generic10)(1, 2, 3, 4, 5, 6, 7, "8", 9, 10));
+Promise<{
+	val1: 1;
+	val2: 2;
+	val3: 3;
+	val4: 4;
+	val5: 5;
+	val6: 6;
+	val7: 7;
+	val8: '8';
+	val9: 9;
+	val10: 10;
+}>
+>(pify(generic10)(1, 2, 3, 4, 5, 6, 7, '8', 9, 10));
 
-// multiArgs
+// MultiArgs
 declare function callback02(cb: (x: number, y: string) => void): void;
-declare function callback12(val: "a", cb: (x: number, y: string) => void): void;
+declare function callback12(value: 'a', cb: (x: number, y: string) => void): void;
 declare function callback22(
-	val1: "a",
-	val2: "b",
+	value1: 'a',
+	value2: 'b',
 	cb: (x: number, y: string) => void
 ): void;
 
-expectType<Promise<[number, string]>>(pify(callback02, { multiArgs: true })());
+expectType<Promise<[number, string]>>(pify(callback02, {multiArgs: true})());
 expectType<Promise<[number, string]>>(
-	pify(callback12, { multiArgs: true })("a")
+	pify(callback12, {multiArgs: true})('a'),
 );
 expectType<Promise<[number, string]>>(
-	pify(callback22, { multiArgs: true })("a", "b")
+	pify(callback22, {multiArgs: true})('a', 'b'),
 );
 
-// overloads
+// Overloads
 declare function overloaded(value: number, cb: (value: number) => void): void;
 declare function overloaded(value: string, cb: (value: string) => void): void;
 
 // Chooses last overload
 // See https://github.com/microsoft/TypeScript/issues/32164
-expectType<Promise<string>>(pify(overloaded)(""));
+expectType<Promise<string>>(pify(overloaded)(''));
 
 declare const fixtureModule: {
 	method1: (arg: string, cb: (error: Error, value: string) => void) => void;
@@ -105,33 +106,33 @@ declare const fixtureModule: {
 	methodStream: (arg: 'stream') => 'stream';
 	callbackEndingInSync: (arg: 'sync', cb: (error: Error, value: 'sync') => void) => void;
 	prop: number;
-}
+};
 
-// module support
+// Module support
 expectType<number>(pify(fixtureModule).prop);
-expectType<Promise<string>>(pify(fixtureModule).method1(""));
+expectType<Promise<string>>(pify(fixtureModule).method1(''));
 expectType<Promise<number>>(pify(fixtureModule).method2(0));
 // Same semantics as pify(fn)
 expectType<never>(pify(fixtureModule).method3());
 
-// excludes
+// Excludes
 expectType<
-	(arg: string, cb: (error: Error, value: string) => void) => void
->(pify(fixtureModule, { exclude: ['method1'] }).method1);
+(arg: string, cb: (error: Error, value: string) => void) => void
+>(pify(fixtureModule, {exclude: ['method1']}).method1);
 
-// includes
-expectType<Promise<string>>(pify(fixtureModule, { include: ['method1'] }).method1(""));
-expectType<Promise<number>>(pify(fixtureModule, { include: ['method2'] }).method2(0));
+// Includes
+expectType<Promise<string>>(pify(fixtureModule, {include: ['method1']}).method1(''));
+expectType<Promise<number>>(pify(fixtureModule, {include: ['method2']}).method2(0));
 
-// excludes sync and stream method by default
+// Excludes sync and stream method by default
 expectType<
-	(arg: 'sync') => 'sync'
->(pify(fixtureModule, { exclude: ['method1'] }).methodSync);
+(arg: 'sync') => 'sync'
+>(pify(fixtureModule, {exclude: ['method1']}).methodSync);
 expectType<
-	(arg: 'stream') => 'stream'
->(pify(fixtureModule, { exclude: ['method1'] }).methodStream);
+(arg: 'stream') => 'stream'
+>(pify(fixtureModule, {exclude: ['method1']}).methodStream);
 
-// include sync method
+// Include sync method
 expectType<
-	(arg: 'sync') => Promise<'sync'>
->(pify(fixtureModule, { include: ['callbackEndingInSync'] }).callbackEndingInSync);
+(arg: 'sync') => Promise<'sync'>
+>(pify(fixtureModule, {include: ['callbackEndingInSync']}).callbackEndingInSync);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -108,3 +108,8 @@ expectType<Promise<string>>(pify(fixtureModule).method1(""));
 expectType<Promise<number>>(pify(fixtureModule).method2(0));
 // Same semantics as pify(fn)
 expectType<never>(pify(fixtureModule).method3());
+
+// excludes
+expectType<
+	(arg: string, cb: (error: Error, value: string) => void) => void
+>(pify(fixtureModule, { exclude: ['method1'] }).method1);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -100,7 +100,10 @@ expectType<Promise<string>>(pify(overloaded)(""));
 declare const fixtureModule: {
 	method1: (arg: string, cb: (error: Error, value: string) => void) => void;
 	method2: (arg: number, cb: (error: Error, value: number) => void) => void;
-	method3: (arg: string) => string
+	method3: (arg: string) => string;
+	methodSync: (arg: 'sync') => 'sync';
+	methodStream: (arg: 'stream') => 'stream';
+	callbackEndingInSync: (arg: 'sync', cb: (error: Error, value: 'sync') => void) => void;
 	prop: number;
 }
 
@@ -115,3 +118,20 @@ expectType<never>(pify(fixtureModule).method3());
 expectType<
 	(arg: string, cb: (error: Error, value: string) => void) => void
 >(pify(fixtureModule, { exclude: ['method1'] }).method1);
+
+// includes
+expectType<Promise<string>>(pify(fixtureModule, { include: ['method1'] }).method1(""));
+expectType<Promise<number>>(pify(fixtureModule, { include: ['method2'] }).method2(0));
+
+// excludes sync and stream method by default
+expectType<
+	(arg: 'sync') => 'sync'
+>(pify(fixtureModule, { exclude: ['method1'] }).methodSync);
+expectType<
+	(arg: 'stream') => 'stream'
+>(pify(fixtureModule, { exclude: ['method1'] }).methodStream);
+
+// include sync method
+expectType<
+	(arg: 'sync') => Promise<'sync'>
+>(pify(fixtureModule, { include: ['callbackEndingInSync'] }).callbackEndingInSync);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -13,8 +13,7 @@ expectError(pify('abc', {}));
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 expectType<never>(pify((v: number) => {})());
-// TODO: Figure out a way for this to return `never`
-expectType<Promise<never>>(pify(() => 'hello')());
+expectType<never>(pify(() => 'hello')());
 
 // Callback with 0 additional params
 declare function fn0(fn: (value: number) => void): void;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,96 @@
+import { expectError, expectType } from "tsd";
+import pify = require(".");
+
+expectError(pify());
+expectError(pify(null));
+expectError(pify(undefined));
+expectError(pify(123));
+expectError(pify("abc"));
+expectError(pify(null, {}));
+expectError(pify(undefined, {}));
+expectError(pify(123, {}));
+expectError(pify("abc", {}));
+
+expectType<never>(pify((v: number) => {})());
+
+// callback with 0 additional params
+declare function fn0(fn: (val: number) => void): void;
+expectType<Promise<number>>(pify(fn0)());
+
+// callback with 1 additional params
+declare function fn1(x: number, fn: (val: number) => void): void;
+expectType<Promise<number>>(pify(fn1)(1));
+
+// callback with 2 additional params
+declare function fn2(x: number, y: number, fn: (val: number) => void): void;
+expectType<Promise<number>>(pify(fn2)(1, 2));
+
+// generics
+
+declare function generic<T>(val: T, fn: (val: T) => void): void;
+declare const genericVal: "hello" | "goodbye";
+expectType<Promise<typeof genericVal>>(pify(generic)(genericVal));
+
+declare function generic10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+	val1: T1,
+	val2: T2,
+	val3: T3,
+	val4: T4,
+	val5: T5,
+	val6: T6,
+	val7: T7,
+	val8: T8,
+	val9: T9,
+	val10: T10,
+	cb: (value: {
+		val1: T1;
+		val2: T2;
+		val3: T3;
+		val4: T4;
+		val5: T5;
+		val6: T6;
+		val7: T7;
+		val8: T8;
+		val9: T9;
+		val10: T10;
+	}) => void
+): void;
+expectType<
+	Promise<{
+		val1: 1;
+		val2: 2;
+		val3: 3;
+		val4: 4;
+		val5: 5;
+		val6: 6;
+		val7: 7;
+		val8: "8";
+		val9: 9;
+		val10: 10;
+	}>
+>(pify(generic10)(1, 2, 3, 4, 5, 6, 7, "8", 9, 10));
+
+// multiArgs
+declare function callback02(cb: (x: number, y: string) => void): void;
+declare function callback12(val: "a", cb: (x: number, y: string) => void): void;
+declare function callback22(
+	val1: "a",
+	val2: "b",
+	cb: (x: number, y: string) => void
+): void;
+
+expectType<Promise<[number, string]>>(pify(callback02, { multiArgs: true })());
+expectType<Promise<[number, string]>>(
+	pify(callback12, { multiArgs: true })("a")
+);
+expectType<Promise<[number, string]>>(
+	pify(callback22, { multiArgs: true })("a", "b")
+);
+
+// overloads
+declare function overloaded(value: number, cb: (value: number) => void): void;
+declare function overloaded(value: string, cb: (value: string) => void): void;
+
+// Chooses last overload
+// See https://github.com/microsoft/TypeScript/issues/32164
+expectType<Promise<string>>(pify(overloaded)(""));

--- a/package.json
+++ b/package.json
@@ -16,11 +16,12 @@
 		"node": ">=14.16"
 	},
 	"scripts": {
-		"test": "xo && ava",
+		"test": "xo && ava && tsd",
 		"optimization-test": "node --allow-natives-syntax optimization-test.js"
 	},
 	"files": [
-		"index.js"
+		"index.js",
+		"index.d.ts"
 	],
 	"keywords": [
 		"promisify",
@@ -45,6 +46,8 @@
 	"devDependencies": {
 		"ava": "^4.3.0",
 		"pinkie-promise": "^2.0.1",
+		"tsd": "^0.19.0",
+		"typescript": "^4.5.4",
 		"v8-natives": "^1.2.5",
 		"xo": "^0.49.0"
 	}

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
 	"devDependencies": {
 		"ava": "^4.3.0",
 		"pinkie-promise": "^2.0.1",
-		"tsd": "^0.19.0",
-		"typescript": "^4.5.4",
+		"tsd": "^0.23.0",
+		"typescript": "^4.8.2",
 		"v8-natives": "^1.2.5",
 		"xo": "^0.49.0"
 	}

--- a/readme.md
+++ b/readme.md
@@ -142,6 +142,22 @@ someClassPromisified.someFunction();
 const someFunction = pify(someClass.someFunction.bind(someClass));
 ```
 
+#### With TypeScript why is `pify` choosing the first function overload?
+
+If you're using TypeScript and your input has [function overloads](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads) then only the first overload will be chosen and promisified.
+
+If you need to choose a different overload consider using a type assertion eg.
+
+```ts
+function overloadedFunction(input: number, cb: (error: unknown, data: number => void): void
+function overloadedFunction(input: string, cb: (error: unknown, data: string) => void): void
+  /* ... */
+}
+
+const fn = pify(overloadedFunction as (input: string, cb: (error: unknown, data: string) => void) => void)
+// ^ ? (input: string) => Promise<string>
+```
+
 ## Related
 
 - [p-event](https://github.com/sindresorhus/p-event) - Promisify an event by waiting for it to be emitted

--- a/readme.md
+++ b/readme.md
@@ -142,9 +142,9 @@ someClassPromisified.someFunction();
 const someFunction = pify(someClass.someFunction.bind(someClass));
 ```
 
-#### With TypeScript why is `pify` choosing the first function overload?
+#### With TypeScript why is `pify` choosing the last function overload?
 
-If you're using TypeScript and your input has [function overloads](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads) then only the first overload will be chosen and promisified.
+If you're using TypeScript and your input has [function overloads](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads) then only the last overload will be chosen and promisified.
 
 If you need to choose a different overload consider using a type assertion eg.
 
@@ -154,8 +154,8 @@ function overloadedFunction(input: string, cb: (error: unknown, data: string) =>
   /* ... */
 }
 
-const fn = pify(overloadedFunction as (input: string, cb: (error: unknown, data: string) => void) => void)
-// ^ ? (input: string) => Promise<string>
+const fn = pify(overloadedFunction as (input: number, cb: (error: unknown, data: number) => void) => void)
+// ^ ? (input: number) => Promise<number>
 ```
 
 ## Related

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
Closes #74 

Pros and cons compared to #85

Pros:

- No need for as many overloads
- Supports as many generics as you like
- Support for as many callback arguments as you like when `multiArgs: true`. Although not sure if this is in scope in the context of the `errorFirst` options.

Cons:

- `pify((v: number) => {})()` returns `Promise<unknown>` instead of erroring - at runtime this promise will simply never resolve or reject. A bit of annoying DX but isn't unsafe.

Todo:

- [x] Promisifying modules with includes and excludes
- [x] Document clearly that overloaded functions are not supported and only the final overload will be chosen: https://github.com/microsoft/TypeScript/issues/32164
- [x] Support `excludeMain`
- [x] Support `errorFirst `


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#74: Add TypeScript type definition](https://issuehunt.io/repos/41585934/issues/74)
---
</details>
<!-- /Issuehunt content-->