### PR TITLE
docs: fix undefined variable and duplicate declaration in class example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -132,14 +132,14 @@ import SomeClass from './some-class.js';
 const someInstance = new SomeClass();
 
 // ❌ `someFunction` can't access its class context.
-const someFunction = pify(someClass.someFunction);
+const someFunction = pify(someInstance.someFunction);
 
 // ✅ The whole class is promisified and the `someFunction` method is called on its class.
-const someClassPromisified = pify(someClass);
+const someClassPromisified = pify(someInstance);
 someClassPromisified.someFunction();
 
 // ✅ `someFunction` is bound to its class before being promisified.
-const someFunction = pify(someClass.someFunction.bind(someClass));
+const someBoundFunction = pify(someInstance.someFunction.bind(someInstance));
 ```
 
 #### Why is `pify` choosing the last function overload when using it with TypeScript?


### PR DESCRIPTION
## Summary
The "How can I promisify a single class method?" FAQ example referenced an undefined `someClass` variable instead of the `someInstance` declared above it, and declared `const someFunction` twice in the same code block.

Copy-pasting the example as-is would throw:
- `ReferenceError: someClass is not defined`
- `SyntaxError: Identifier 'someFunction' has already been declared`

## Changes
- Replaced `someClass` with `someInstance` (the actual declared variable) in all three usages
- Renamed the second `someFunction` to `someBoundFunction` to avoid the duplicate `const` declaration

Docs-only change, no code/behavior affected.
